### PR TITLE
upstream: always remove keepalive close event on shutdown if registered

### DIFF
--- a/src/flb_upstream.c
+++ b/src/flb_upstream.c
@@ -442,7 +442,7 @@ static int prepare_destroy_conn(struct flb_upstream_conn *u_conn)
     flb_trace("[upstream] destroy connection #%i to %s:%i",
               u_conn->fd, u->tcp_host, u->tcp_port);
 
-    if (u->flags & FLB_IO_ASYNC || u_conn->ka_dropped_event_added == FLB_TRUE) {
+    if (MK_EVENT_IS_REGISTERED((&u_conn->event))) {
         mk_event_del(u_conn->evl, &u_conn->event);
     }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->

This PR cherry-picks the commit from the upstream fluent bit repository: https://github.com/fluent/fluent-bit/pull/6845.

> Currently the keepalive dropped connection event is only removed in the async case. However, sync connections can also have keepalive. This PR ensures the event is always removed if it was added.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

Addresses https://github.com/aws/aws-for-fluent-bit/issues/840 and https://github.com/aws/aws-for-fluent-bit/issues/828

**Testing**

We built a test image with this cherry pick commit. Customer and support team that hit the issue, are no longer seeing the it occur.

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
