### PR TITLE
out_cloudwatch: add account ID support for CloudWatch entity

### DIFF
--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -467,6 +467,32 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
         ctx->new_keys++;
     }
 
+    if (ctx->enable_entity) {
+        if (!ctx->account_id) {
+            ret = get_metadata_by_key(ctx, FLB_FILTER_AWS_IMDS_ACCOUNT_ID_PATH,
+                                  &ctx->account_id, &ctx->account_id_len,
+                                  "accountId");
+            if (ret < 0) {
+                return -1;
+            }
+            ctx->new_keys++;
+        } else {
+            ctx->new_keys++;
+        }
+
+        if (!ctx->instance_id) {
+            ret = get_metadata(ctx, FLB_FILTER_AWS_IMDS_INSTANCE_ID_PATH,
+                   &ctx->instance_id, &ctx->instance_id_len);
+
+            if (ret < 0) {
+                return -1;
+            }
+            ctx->new_keys++;
+        } else {
+            ctx->new_keys++;
+        }
+    }
+
     ctx->metadata_retrieved = FLB_TRUE;
     return 0;
 }
@@ -558,19 +584,11 @@ static int cb_aws_filter(const void *data, size_t bytes,
                                   ctx->availability_zone_len);
         }
 
-        if (ctx->instance_id_include && !ctx->enable_entity) {
+        if (ctx->instance_id_include) {
             msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_INSTANCE_ID_KEY_LEN);
             msgpack_pack_str_body(&tmp_pck,
                                   FLB_FILTER_AWS_INSTANCE_ID_KEY,
                                   FLB_FILTER_AWS_INSTANCE_ID_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, ctx->instance_id_len);
-            msgpack_pack_str_body(&tmp_pck,
-                                  ctx->instance_id, ctx->instance_id_len);
-        } else if (ctx->instance_id_include && ctx->enable_entity) {
-            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
-            msgpack_pack_str_body(&tmp_pck,
-                                  FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY,
-                                  FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
             msgpack_pack_str(&tmp_pck, ctx->instance_id_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->instance_id, ctx->instance_id_len);
@@ -616,19 +634,11 @@ static int cb_aws_filter(const void *data, size_t bytes,
                                   ctx->ami_id, ctx->ami_id_len);
         }
 
-        if (ctx->account_id_include && !ctx->enable_entity) {
+        if (ctx->account_id_include) {
             msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ACCOUNT_ID_KEY_LEN);
             msgpack_pack_str_body(&tmp_pck,
                                   FLB_FILTER_AWS_ACCOUNT_ID_KEY,
                                   FLB_FILTER_AWS_ACCOUNT_ID_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, ctx->account_id_len);
-            msgpack_pack_str_body(&tmp_pck,
-                                  ctx->account_id, ctx->account_id_len);
-        } else if (ctx->account_id_include && ctx->enable_entity) {
-            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN);
-            msgpack_pack_str_body(&tmp_pck,
-                                  FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY,
-                                  FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN);
             msgpack_pack_str(&tmp_pck, ctx->account_id_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->account_id, ctx->account_id_len);
@@ -642,6 +652,26 @@ static int cb_aws_filter(const void *data, size_t bytes,
             msgpack_pack_str(&tmp_pck, ctx->hostname_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->hostname, ctx->hostname_len);
+        }
+
+        if (ctx->enable_entity && ctx->instance_id != NULL && ctx->account_id != NULL) {
+            // Pack instance ID with entity prefix for further processing
+            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
+            msgpack_pack_str_body(&tmp_pck,
+                                  FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY,
+                                  FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
+            msgpack_pack_str(&tmp_pck, ctx->instance_id_len);
+            msgpack_pack_str_body(&tmp_pck,
+                                  ctx->instance_id, ctx->instance_id_len);
+
+            // Pack account ID with entity prefix for further processing
+            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN);
+            msgpack_pack_str_body(&tmp_pck,
+                                  FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY,
+                                  FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN);
+            msgpack_pack_str(&tmp_pck, ctx->account_id_len);
+            msgpack_pack_str_body(&tmp_pck,
+                                  ctx->account_id, ctx->account_id_len);
         }
     }
     msgpack_unpacked_destroy(&result);

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -616,11 +616,19 @@ static int cb_aws_filter(const void *data, size_t bytes,
                                   ctx->ami_id, ctx->ami_id_len);
         }
 
-        if (ctx->account_id_include) {
+        if (ctx->account_id_include && !ctx->enable_entity) {
             msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ACCOUNT_ID_KEY_LEN);
             msgpack_pack_str_body(&tmp_pck,
                                   FLB_FILTER_AWS_ACCOUNT_ID_KEY,
                                   FLB_FILTER_AWS_ACCOUNT_ID_KEY_LEN);
+            msgpack_pack_str(&tmp_pck, ctx->account_id_len);
+            msgpack_pack_str_body(&tmp_pck,
+                                  ctx->account_id, ctx->account_id_len);
+        } else if (ctx->account_id_include && ctx->enable_entity) {
+            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN);
+            msgpack_pack_str_body(&tmp_pck,
+                                  FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY,
+                                  FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN);
             msgpack_pack_str(&tmp_pck, ctx->account_id_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->account_id, ctx->account_id_len);

--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -63,6 +63,8 @@
 #define FLB_FILTER_AWS_AMI_ID_KEY_LEN                     6
 #define FLB_FILTER_AWS_ACCOUNT_ID_KEY                     "account_id"
 #define FLB_FILTER_AWS_ACCOUNT_ID_KEY_LEN                 10
+#define FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY              "aws_entity_account_id"
+#define FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN          21
 #define FLB_FILTER_AWS_HOSTNAME_KEY                       "hostname"
 #define FLB_FILTER_AWS_HOSTNAME_KEY_LEN                   8
 

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -368,7 +368,7 @@ static int init_put_payload(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     }
     // If we are missing the service name, the entity will get rejected by the frontend anyway
     // so do not emit entity unless service name is filled
-    if(ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL && stream->entity->key_attributes->name != NULL) {
+    if(ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL && stream->entity->key_attributes->name != NULL && stream->entity->key_attributes->account_id != NULL) {
         if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
                       "\"entity\":{", 10)) {
             goto error;

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -367,7 +367,8 @@ static int init_put_payload(struct flb_cloudwatch *ctx, struct cw_flush *buf,
         goto error;
     }
     // If we are missing the service name, the entity will get rejected by the frontend anyway
-    // so do not emit entity unless service name is filled
+    // so do not emit entity unless service name is filled. If we are missing account ID
+    // it is considered not having sufficient information for entity therefore we should drop the entity.
     if(ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL && stream->entity->key_attributes->name != NULL && stream->entity->key_attributes->account_id != NULL) {
         if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
                       "\"entity\":{", 10)) {

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -221,6 +221,14 @@ static int entity_add_key_attributes(struct flb_cloudwatch *ctx, struct cw_flush
             goto error;
         }
     }
+    if(stream->entity->key_attributes->account_id != NULL && strlen(stream->entity->key_attributes->account_id) != 0) {
+        if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"AwsAccountId\":\"",stream->entity->key_attributes->account_id,"\"")) {
+            goto error;
+        }
+        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,ts,0)) {
+            goto error;
+        }
+    }
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
               "},", 2)) {
         goto error;
@@ -1108,6 +1116,14 @@ void parse_entity(struct flb_cloudwatch *ctx, entity *entity, msgpack_object map
                 flb_free(entity->attributes->instance_id);
             }
             entity->attributes->instance_id = flb_strndup(val.via.str.ptr, val.via.str.size);
+        }
+        if(strncmp(key.via.str.ptr, "aws_entity_account_id",key.via.str.size ) == 0 ) {
+            if(entity->key_attributes->account_id == NULL) {
+                entity->root_filter_count++;
+            } else {
+                flb_free(entity->key_attributes->account_id);
+            }
+            entity->key_attributes->account_id = flb_strndup(val.via.str.ptr, val.via.str.size);
         }
     }
     if(entity->key_attributes->name == NULL && entity->attributes->name_source == NULL &&entity->attributes->workload != NULL) {

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -515,6 +515,7 @@ void entity_destroy(entity *entity) {
         flb_free(entity->key_attributes->environment);
         flb_free(entity->key_attributes->name);
         flb_free(entity->key_attributes->type);
+        flb_free(entity->key_attributes->account_id);
         flb_free(entity->key_attributes);
     }
     flb_free(entity);

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -48,6 +48,7 @@ typedef struct entity_key_attributes {
     char *type;
     char *name;
     char *environment;
+    char *account_id;
 }entity_key_attributes;
 
 /* Attributes used for CloudWatch Entity object


### PR DESCRIPTION
<!-- Provide summary of changes -->
## Summary
CloudWatch entity needs account ID in the entity field to ensure entity does not leak outside the existing account. We also need to drop entity on client side if account ID is not filled out because backend does not have the functionality to smartly decide when to drop entity. 

For example, if user A vends logs to user B, but account id is not in entity, backend will think the entity is sent to customer A's account, so user B will incorrectly get the entity from user A. In this case we need to drop the entity on client-side to prevent account information leaking outside the current account.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
### Config without account ID set in aws plugin
```
[INPUT]
  Name                tail
  Tag                 application.*
  Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
  Path                /var/log/containers/*.log
  multiline.parser    docker, cri
  DB                  /var/fluent-bit/state/flb_container.db
  Mem_Buf_Limit       50MB
  Skip_Long_Lines     On
  Refresh_Interval    10
  Rotate_Wait         30
  storage.type        filesystem
  Read_from_Head      ${READ_FROM_HEAD}

[INPUT]
  Name                tail
  Tag                 application.*
  Path                /var/log/containers/fluent-bit*
  multiline.parser    docker, cri
  DB                  /var/fluent-bit/state/flb_log.db
  Mem_Buf_Limit       5MB
  Skip_Long_Lines     On
  Refresh_Interval    10
  Read_from_Head      ${READ_FROM_HEAD}

[INPUT]
  Name                tail
  Tag                 application.*
  Path                /var/log/containers/cloudwatch-agent*
  multiline.parser    docker, cri
  DB                  /var/fluent-bit/state/flb_cwagent.db
  Mem_Buf_Limit       5MB
  Skip_Long_Lines     On
  Refresh_Interval    10
  Read_from_Head      ${READ_FROM_HEAD}

[FILTER]
  Name                aws
  Match               application.*
  enable_entity       true

[FILTER]
  Name                kubernetes
  Match               application.*
  Kube_URL            https://kubernetes.default.svc:443
  Kube_Tag_Prefix     application.var.log.containers.
  Merge_Log           On
  Merge_Log_Key       log_processed
  K8S-Logging.Parser  On
  K8S-Logging.Exclude Off
  Labels              Off
  Annotations         Off
  Use_Kubelet         On
  Kubelet_Port        10250
  Buffer_Size         0
  use_pod_association true
[OUTPUT]
  Name                cloudwatch_logs
  Match               application.*
  region              ${AWS_REGION}
  log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
  log_stream_prefix   ${HOST_NAME}-
  auto_create_group   true
  extra_user_agent    container-insights
  add_entity          true
```

- [x] Debug log output from testing the change
### Output without AccountId
We can see the entity is using the backend fallback entity
![Screenshot 2024-10-30 at 12 43 21 PM](https://github.com/user-attachments/assets/f9db9512-23ca-455b-a92c-5d8d8a2e9bf6)

### Output with AccountId when sending out of current account
![image](https://github.com/user-attachments/assets/0c505699-89e6-4b52-8732-6c12e2ce750e)


### Output without entity flags
This shows that we are still backward compatible
```
│ [2024/10/30 17:28:27] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] cloudwatch:PutLogEvents: events=1137, payload=1047258 bytes                                                                                                                                                                                               │
│ [2024/10/30 17:28:27] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] Sending log events to log stream ip-192-168-63-18.ec2.internal-application.var.log.containers.fluent-bit-89wq8_amazon-cloudwatch_fluent-bit-84f776762608546d312d87eeb428c9c9f7bb164c35c97a754ad8797c43f474df.log                                          │
│ [2024/10/30 17:28:27] [debug] [upstream] KA connection #194 to logs.us-east-1.amazonaws.com:443 has been assigned (recycled)                                                                                                                                                                                                       │
│ [2024/10/30 17:28:27] [debug] [http_client] not using http_proxy for header                                                                                                                                                                                                                                                        │
│ [2024/10/30 17:28:27] [debug] [aws_credentials] Requesting credentials from the EC2 provider..                                                                                                                                                                                                                                     │
│ [2024/10/30 17:28:27] [debug] [upstream] KA connection #199 to logs.us-east-1.amazonaws.com:443 is now available                                                                                                                                                                                                                   │
│ [2024/10/30 17:28:27] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=200                                                                                                                                                                                                                              │
│ [2024/10/30 17:28:27] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http data=HTTP/1.1 200 OK                                                                                                                                                                                                                    │
│ x-amzn-RequestId: fa396d26-8fae-4120-890e-bdeb7fbfb38b                                                                                                                                                                                                                                                                             │
│ Content-Type: application/x-amz-json-1.1                                                                                                                                                                                                                                                                                           │
│ Content-Length: 80                                                                                                                                                                                                                                                                                                                 │
│ Date: Wed, 30 Oct 2024 17:28:27 GMT                                                                                                                                                                                                                                                                                                │
│                                                                                                                                                                                                                                                                                                                                    │
│ {"nextSequenceToken":"49654323146657947237151620017781351458997669782897034498"}                                                                                                                                                                                                                                                   │
│ [2024/10/30 17:28:27] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http payload={"nextSequenceToken":"49654323146657947237151620017781351458997669782897034498"}                                                                                                                                                │
│ [2024/10/30 17:28:27] [debug] [upstream] KA connection #196 to logs.us-east-1.amazonaws.com:443 is now available                                                                                                                                                                                                                   │
│ [2024/10/30 17:28:27] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http status=200                                                                                                                                                                                                                              │
│ [2024/10/30 17:28:27] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http data=HTTP/1.1 200 OK                                                                                                                                                                                                                    │
│ x-amzn-RequestId: 2910c0a8-4bcc-4110-903a-59cc8c88b761                                                                                                                                                                                                                                                                             │
│ Content-Type: application/x-amz-json-1.1                                                                                                                                                                                                                                                                                           │
│ Content-Length: 80                                                                                                                                                                                                                                                                                                                 │
│ Date: Wed, 30 Oct 2024 17:28:27 GMT                                                                                                                                                                                                                                                                                                │
│                                                                                                                                                                                                                                                                                                                                    │
│ {"nextSequenceToken":"49656145141491667532279081537089852841793243498340681506"}                                                                                                                                                                                                                                                   │
│ [2024/10/30 17:28:27] [debug] [output:cloudwatch_logs:cloudwatch_logs.0] PutLogEvents http payload={"nextSequenceToken":"49656145141491667532279081537089852841793243498340681506"}
```
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
```
[ OK ]
==20691==
==20691== HEAP SUMMARY:
==20691==     in use at exit: 144 bytes in 1 blocks
==20691==   total heap usage: 6,761 allocs, 6,760 frees, 6,400,590 bytes allocated
==20691==
==20691== 144 bytes in 1 blocks are still reachable in loss record 1 of 1
==20691==    at 0x4C31C1D: calloc (vg_replace_malloc.c:1328)
==20691==    by 0x447E02: main (acutest.h:1632)
==20691==
==20691== LEAK SUMMARY:
==20691==    definitely lost: 0 bytes in 0 blocks
==20691==    indirectly lost: 0 bytes in 0 blocks
==20691==      possibly lost: 0 bytes in 0 blocks
==20691==    still reachable: 144 bytes in 1 blocks
==20691==         suppressed: 0 bytes in 0 blocks
==20691==
==20691== For lists of detected and suppressed errors, rerun with: -s
==20691== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
SUCCESS: All unit tests have passed.
==19745==
==19745== HEAP SUMMARY:
==19745==     in use at exit: 0 bytes in 0 blocks
==19745==   total heap usage: 2 allocs, 2 frees, 1,168 bytes allocated
==19745==
==19745== All heap blocks were freed -- no leaks are possible
==19745==
==19745== For lists of detected and suppressed errors, rerun with: -s
==19745== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
