### PR TITLE
filter_aws: Adds resource entity to PLE calls in cloudwatch logs plugin for dataplane and host logs

### DIFF
--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -953,16 +953,7 @@ static int cb_aws_filter(const void *data, size_t bytes,
                                   ctx->hostname, ctx->hostname_len);
         }
 
-        if (ctx->enable_entity && ctx->instance_id != NULL && ctx->account_id != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
-            // Pack instance ID with entity prefix for further processing
-            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
-            msgpack_pack_str_body(&tmp_pck,
-                                  FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY,
-                                  FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, ctx->instance_id_len);
-            msgpack_pack_str_body(&tmp_pck,
-                                  ctx->instance_id, ctx->instance_id_len);
-
+        if (ctx->enable_entity && ctx->account_id != NULL ) {
             // Pack account ID with entity prefix for further processing
             msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN);
             msgpack_pack_str_body(&tmp_pck,
@@ -971,25 +962,36 @@ static int cb_aws_filter(const void *data, size_t bytes,
             msgpack_pack_str(&tmp_pck, ctx->account_id_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->account_id, ctx->account_id_len);
-        }
+            
+            if (ctx->instance_id != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
+                // Pack instance ID with entity prefix for further processing
+                msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
+                msgpack_pack_str_body(&tmp_pck,
+                                    FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY,
+                                    FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
+                msgpack_pack_str(&tmp_pck, ctx->instance_id_len);
+                msgpack_pack_str_body(&tmp_pck,
+                                    ctx->instance_id, ctx->instance_id_len);
+            }
 
-        if (ctx->enable_entity && ctx->cluster != NULL && ctx->platform != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 ) {
-            // Pack cluster name with entity prefix for further processing
-            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN);
-            msgpack_pack_str_body(&tmp_pck,
-                                  FLB_FILTER_AWS_ENTITY_CLUSTER_KEY,
-                                  FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, ctx->cluster_len);
-            msgpack_pack_str_body(&tmp_pck,
-                                  ctx->cluster, ctx->cluster_len);
-           // Pack platform with entity prefix for further processing
-            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN);
-            msgpack_pack_str_body(&tmp_pck,
-                                  FLB_FILTER_AWS_ENTITY_PLATFORM_KEY,
-                                  FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, ctx->platform_len);
-            msgpack_pack_str_body(&tmp_pck,
-                                  ctx->platform, ctx->platform_len);
+            if (ctx->cluster != NULL && ctx->platform != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 ) {
+                // Pack cluster name with entity prefix for further processing
+                msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN);
+                msgpack_pack_str_body(&tmp_pck,
+                                    FLB_FILTER_AWS_ENTITY_CLUSTER_KEY,
+                                    FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN);
+                msgpack_pack_str(&tmp_pck, ctx->cluster_len);
+                msgpack_pack_str_body(&tmp_pck,
+                                    ctx->cluster, ctx->cluster_len);
+                // Pack platform with entity prefix for further processing
+                msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN);
+                msgpack_pack_str_body(&tmp_pck,
+                                    FLB_FILTER_AWS_ENTITY_PLATFORM_KEY,
+                                    FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN);
+                msgpack_pack_str(&tmp_pck, ctx->platform_len);
+                msgpack_pack_str_body(&tmp_pck,
+                                    ctx->platform, ctx->platform_len);
+            }
         }
 
     }

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -1137,7 +1137,7 @@ static struct flb_config_map config_map[] = {
     {
     FLB_CONFIG_MAP_STR, "entity_type", "service",
     0, FLB_TRUE, offsetof(struct flb_filter_aws, entity_type),
-    "Defines the type of entity and adds related entity fields"
+    "Defines the type of entity and adds related entity fields."
     "Possible values Service or Resource"
     },
     {

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -788,12 +788,9 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
       }
 
       if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
-        flb_plg_info(ctx->ins, "getting cluster name and platform in aws plugin");
         get_cluster_from_environment(ctx);
         get_platform(ctx);
       }
-      // new keys for entity type field which should be added to message pack
-      ctx->new_keys++;
     }
 
     ctx->metadata_retrieved = FLB_TRUE;
@@ -975,14 +972,6 @@ static int cb_aws_filter(const void *data, size_t bytes,
             msgpack_pack_str(&tmp_pck, ctx->account_id_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->account_id, ctx->account_id_len);
-            // Pack entity type with entity prefix for further processing
-            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
-            msgpack_pack_str_body(&tmp_pck,
-                                  FLB_FILTER_AWS_ENTITY_TYPE_KEY,
-                                  FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, strlen(ctx->entity_type));
-            msgpack_pack_str_body(&tmp_pck,
-                                  ctx->entity_type, strlen(ctx->entity_type));
         }
 
         if (ctx->enable_entity && ctx->cluster != NULL && ctx->platform != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 ) {
@@ -1002,14 +991,6 @@ static int cb_aws_filter(const void *data, size_t bytes,
             msgpack_pack_str(&tmp_pck, ctx->platform_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->platform, ctx->platform_len);
-            // Pack entity type with entity prefix for further processing
-            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
-            msgpack_pack_str_body(&tmp_pck,
-                                  FLB_FILTER_AWS_ENTITY_TYPE_KEY,
-                                  FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, strlen(ctx->entity_type));
-            msgpack_pack_str_body(&tmp_pck,
-                                  ctx->entity_type, strlen(ctx->entity_type));
         }
 
     }

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -405,7 +405,7 @@ static void get_cluster_from_environment(struct flb_filter_aws *ctx)
     if(ctx->cluster == NULL) {
         char* cluster_name = getenv("CLUSTER_NAME");
         if(cluster_name) {
-            ctx->cluster = strdup(cluster_name);
+            ctx->cluster = flb_strdup(cluster_name);
             ctx->cluster_len = strlen(cluster_name);
             ctx->new_keys++;
         } else {
@@ -469,7 +469,7 @@ static int get_http_auth_header(struct flb_filter_aws *ctx)
     if (ret == -1) {
         flb_plg_warn(ctx->ins, "cannot open %s", FLB_KUBE_TOKEN);
     }
-    flb_plg_info(ctx->ins, " token updated");
+    flb_plg_info(ctx->ins, " token updated", FLB_KUBE_TOKEN);
     ctx->kube_token_create = time(NULL);
 
     /* Token */
@@ -527,7 +527,7 @@ static int refresh_token_if_needed(struct flb_filter_aws *ctx)
 }
 
 /* Gather metadata from HTTP Request,
- * this could send out HTTP Request either to KUBE Server API or Kubelet
+ * this could send out HTTP Request to KUBE Server API
  */
 static int get_meta_info_from_request(struct flb_filter_aws *ctx,
                                       struct flb_upstream *upstream,
@@ -624,7 +624,7 @@ static int get_api_server_configmap(struct flb_filter_aws *ctx,
         }
         flb_plg_debug(ctx->ins,
                       "Send out request to API Server for configmap information in aws plugin");
-        packed = get_meta_info_from_request(ctx,ctx->kubernetes_upstream, namespace,FLB_KUBE_CONFIGMAP, configmap,
+        packed = get_meta_info_from_request(ctx, ctx->kubernetes_upstream, namespace, FLB_KUBE_CONFIGMAP, configmap,
                                     &buf, &size, &root_type, uri);
     }
 
@@ -655,6 +655,9 @@ static void get_platform(struct flb_filter_aws *ctx)
         ctx->platform_len = strlen(ctx->platform);
         ctx->new_keys++;
         flb_plg_debug(ctx->ins, "Platform type is %s.", ctx->platform);
+        if(config_buf) {
+            flb_free(config_buf);
+        }
     }
 }
 

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -105,6 +105,31 @@ static void expose_aws_meta(struct flb_filter_aws *ctx)
     }
 }
 
+static void create_kubernetes_upstream(struct flb_filter_aws *ctx, struct flb_config *config) {
+    ctx->kubernetes_upstream = NULL;
+
+    ctx->tls = flb_tls_create(ctx->tls_verify,
+                                  ctx->tls_debug,
+                                  ctx->tls_vhost,
+                                  ctx->tls_ca_path,
+                                  ctx->tls_ca_file,
+                                  NULL, NULL, NULL);
+    if (!ctx->tls) {
+        flb_plg_error(ctx->ins, "tls creation failed in creating k8s upstream");
+    }
+
+    /* Create an Upstream context */
+    ctx->kubernetes_upstream = flb_upstream_create(config,
+                                    flb_strdup(FLB_API_HOST),
+                                    FLB_API_PORT,
+                                    FLB_IO_TLS,
+                                    ctx->tls);
+    flb_plg_info(ctx->ins, "kubernetes upstream connection created in aws plugin");
+    if (!ctx->kubernetes_upstream) {
+        flb_plg_info(ctx->ins, "kubernetes upstream connection initialization error in aws plugin");
+    }
+}
+
 static int cb_aws_init(struct flb_filter_instance *f_ins,
                        struct flb_config *config,
                        void *data)
@@ -166,6 +191,12 @@ static int cb_aws_init(struct flb_filter_instance *f_ins,
     /* Remove async flag from upstream */
     ctx->ec2_upstream->flags &= ~(FLB_IO_ASYNC);
 
+    /*Create kubernetes upstream to query k8s api to define the platform type*/
+    if (ctx->enable_entity && strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
+        create_kubernetes_upstream(ctx, config);
+    }
+    ctx->kube_token_create = 0;
+
     /* Retrieve metadata */
     ret = get_ec2_metadata(ctx);
     if (ret < 0) {
@@ -178,18 +209,6 @@ static int cb_aws_init(struct flb_filter_instance *f_ins,
     }
     else {
         expose_aws_meta(ctx);
-    }
-
-    if (ctx->enable_entity && strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
-       ctx->kubernetes_upstream = flb_upstream_create(config,
-                                    FLB_API_HOST,
-                                    FLB_API_PORT,
-                                    FLB_IO_TLS,
-                                    NULL);
-        flb_plg_info(ctx->ins, "kubernetes upstream connection created in aws plugin");
-    }
-    if (!ctx->kubernetes_upstream) {
-        flb_plg_info(ctx->ins, "kubernetes upstream connection initialization error in aws plugin");
     }
     flb_filter_set_context(f_ins, ctx);
     return 0;
@@ -451,7 +470,7 @@ static int get_http_auth_header(struct flb_filter_aws *ctx)
     if (ret == -1) {
         flb_plg_warn(ctx->ins, "cannot open %s", FLB_KUBE_TOKEN);
     }
-    flb_plg_info(ctx->ins, " token updated", FLB_KUBE_TOKEN);
+    flb_plg_info(ctx->ins, " token updated");
     ctx->kube_token_create = time(NULL);
 
     /* Token */
@@ -544,9 +563,6 @@ static int get_meta_info_from_request(struct flb_filter_aws *ctx,
         flb_plg_error(ctx->ins, "failed to refresh token");
         return -1;
     }
-
-    /* Buffer size for HTTP Client when reading responses from API Server */
-    ctx->buffer_size = 32000;
 
     /* Compose HTTP Client request*/
     c = flb_http_client(u_conn, FLB_HTTP_GET,
@@ -942,8 +958,6 @@ static int cb_aws_filter(const void *data, size_t bytes,
         }
 
         if (ctx->enable_entity && ctx->instance_id != NULL && ctx->account_id != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
-            flb_plg_info(ctx->ins,
-                      "Adding instance id and account id to message pack");
             // Pack instance ID with entity prefix for further processing
             msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
             msgpack_pack_str_body(&tmp_pck,
@@ -971,9 +985,7 @@ static int cb_aws_filter(const void *data, size_t bytes,
                                   ctx->entity_type, strlen(ctx->entity_type));
         }
 
-        if (ctx->enable_entity && ctx->cluster !=NULL && ctx->platform != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 ) {
-            flb_plg_info(ctx->ins,
-                      "Adding cluster name and type to message pack");
+        if (ctx->enable_entity && ctx->cluster != NULL && ctx->platform != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 ) {
             // Pack cluster name with entity prefix for further processing
             msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN);
             msgpack_pack_str_body(&tmp_pck,
@@ -1066,6 +1078,8 @@ static void flb_filter_aws_destroy(struct flb_filter_aws *ctx)
     if(ctx->entity_type){
         flb_sds_destroy(ctx->entity_type);
     }
+    flb_free(ctx->token);
+    flb_free(ctx->auth);
     flb_free(ctx);
 }
 
@@ -1144,6 +1158,48 @@ static struct flb_config_map config_map[] = {
      FLB_CONFIG_MAP_TIME, "kube_token_ttl", "10m",
      0, FLB_TRUE, offsetof(struct flb_filter_aws, kube_token_ttl),
      "kubernetes token ttl, until it is reread from the token file. Default: 10m"
+    },
+    /* Buffer size for HTTP Client when reading responses from API Server */
+    {
+     FLB_CONFIG_MAP_SIZE, "buffer_size", "32K",
+     0, FLB_TRUE, offsetof(struct flb_filter_aws, buffer_size),
+     "buffer size to receive response from API server",
+    },
+
+    /* TLS: set debug 'level' */
+    {
+     FLB_CONFIG_MAP_INT, "tls.debug", "0",
+     0, FLB_TRUE, offsetof(struct flb_filter_aws, tls_debug),
+     "set TLS debug level: 0 (no debug), 1 (error), "
+     "2 (state change), 3 (info) and 4 (verbose)"
+    },
+
+    /* TLS: enable verification */
+    {
+     FLB_CONFIG_MAP_BOOL, "tls.verify", "true",
+     0, FLB_TRUE, offsetof(struct flb_filter_aws, tls_verify),
+     "enable or disable verification of TLS peer certificate"
+    },
+
+    /* TLS: set tls.vhost feature */
+    {
+     FLB_CONFIG_MAP_STR, "tls.vhost", NULL,
+     0, FLB_TRUE, offsetof(struct flb_filter_aws, tls_vhost),
+     "set optional TLS virtual host"
+    },
+
+        /* Kubernetes TLS: CA file */
+    {
+     FLB_CONFIG_MAP_STR, "kube_ca_file", FLB_KUBE_CA,
+     0, FLB_TRUE, offsetof(struct flb_filter_aws, tls_ca_file),
+     "Kubernetes TLS CA file"
+    },
+
+    /* Kubernetes TLS: CA certs path */
+    {
+     FLB_CONFIG_MAP_STR, "kube_ca_path", NULL,
+     0, FLB_TRUE, offsetof(struct flb_filter_aws, tls_ca_path),
+     "Kubernetes TLS ca path"
     },
     {0}
 };

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -770,7 +770,6 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
         } else {
             ctx->new_keys++;
         }
-      if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
         if (!ctx->instance_id) {
             ret = get_metadata(ctx, FLB_FILTER_AWS_IMDS_INSTANCE_ID_PATH,
                    &ctx->instance_id, &ctx->instance_id_len);
@@ -782,13 +781,12 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
         } else {
             ctx->new_keys++;
         }
-      }
-      ctx->cluster = NULL;
-      ctx->platform = NULL;
-      if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
-        get_cluster_from_environment(ctx);
-        get_platform(ctx);
-      }
+        ctx->cluster = NULL;
+        ctx->platform = NULL;
+        if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
+            get_cluster_from_environment(ctx);
+            get_platform(ctx);
+        }
     }
 
     ctx->metadata_retrieved = FLB_TRUE;
@@ -962,7 +960,7 @@ static int cb_aws_filter(const void *data, size_t bytes,
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->account_id, ctx->account_id_len);
             
-            if (ctx->instance_id != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
+            if (ctx->instance_id != NULL) {
                 // Pack instance ID with entity prefix for further processing
                 msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
                 msgpack_pack_str_body(&tmp_pck,

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -34,6 +34,7 @@
 
 #include <monkey/mk_core/mk_list.h>
 #include <msgpack.h>
+#include <sys/stat.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -185,9 +186,10 @@ static int cb_aws_init(struct flb_filter_instance *f_ins,
                                     FLB_API_PORT,
                                     FLB_IO_TLS,
                                     NULL);
+        flb_plg_info(ctx->ins, "kubernetes upstream connection created in aws plugin");
     }
     if (!ctx->kubernetes_upstream) {
-        flb_plg_debug(ctx->ins, "kubernetes upstream connection initialization error in aws plugin");
+        flb_plg_info(ctx->ins, "kubernetes upstream connection initialization error in aws plugin");
     }
     flb_filter_set_context(f_ins, ctx);
     return 0;
@@ -391,8 +393,119 @@ static void get_cluster_from_environment(struct flb_filter_aws *ctx)
         } else {
             free(cluster_name);
         }
-        flb_plg_debug(ctx->ins, "Cluster name is %s.", ctx->cluster);
+        flb_plg_info(ctx->ins, "Cluster name is %s.", ctx->cluster);
     }
+}
+
+static int file_to_buffer(const char *path,
+                          char **out_buf, size_t *out_size)
+{
+    int ret;
+    char *buf;
+    ssize_t bytes;
+    FILE *fp;
+    struct stat st;
+
+    if (!(fp = fopen(path, "r"))) {
+        return -1;
+    }
+
+    ret = stat(path, &st);
+    if (ret == -1) {
+        flb_errno();
+        fclose(fp);
+        return -1;
+    }
+
+    buf = flb_calloc(1, (st.st_size + 1));
+    if (!buf) {
+        flb_errno();
+        fclose(fp);
+        return -1;
+    }
+
+    bytes = fread(buf, st.st_size, 1, fp);
+    if (bytes < 1) {
+        flb_free(buf);
+        fclose(fp);
+        return -1;
+    }
+
+    fclose(fp);
+
+    *out_buf = buf;
+    *out_size = st.st_size;
+
+    return 0;
+}
+
+/* Set K8s Authorization Token and get HTTP Auth Header */
+static int get_http_auth_header(struct flb_filter_aws *ctx) 
+{
+    int ret;
+    char *temp;
+    char *tk = NULL;
+    size_t tk_size = 0;
+
+    ret = file_to_buffer(FLB_KUBE_TOKEN, &tk, &tk_size);
+    if (ret == -1) {
+        flb_plg_warn(ctx->ins, "cannot open %s", FLB_KUBE_TOKEN);
+    }
+    flb_plg_info(ctx->ins, " token updated", FLB_KUBE_TOKEN);
+    ctx->kube_token_create = time(NULL);
+
+    /* Token */
+    if (ctx->token != NULL) {
+        flb_free(ctx->token);
+    }
+    ctx->token = tk;
+    ctx->token_len = tk_size;
+
+    /* HTTP Auth Header */
+    if (ctx->auth == NULL) {
+        ctx->auth = flb_malloc(tk_size + 32);
+    }
+    else if (ctx->auth_len < tk_size + 32) {
+        temp = flb_realloc(ctx->auth, tk_size + 32);
+        if (temp == NULL) {
+            flb_free(ctx->auth);
+            ctx->auth = NULL;
+            return -1;
+        } 
+        ctx->auth = temp;
+    }
+    
+    if (!ctx->auth) {
+        return -1;
+    }
+    ctx->auth_len = snprintf(ctx->auth, tk_size + 32,
+                             "Bearer %s",
+                             tk);
+    
+    return 0;
+}
+
+/* Refresh HTTP Auth Header if K8s Authorization Token is expired */
+static int refresh_token_if_needed(struct flb_filter_aws *ctx)
+{
+    int expired = 0;
+    int ret;
+
+    if (ctx->kube_token_create > 0) {
+        if (time(NULL) > ctx->kube_token_create + ctx->kube_token_ttl) {
+            expired = FLB_TRUE;
+        }
+    }
+
+    if (expired || ctx->kube_token_create == 0) {
+        ret = get_http_auth_header(ctx);
+        if (ret == -1) {
+            flb_plg_warn(ctx->ins, "failed to set http auth header");
+            return -1;
+        }
+    }
+
+    return 0;
 }
 
 /* Gather metadata from HTTP Request,
@@ -407,6 +520,8 @@ static int get_meta_info_from_request(struct flb_filter_aws *ctx,
                                       int *root_type,
                                       char* uri)
 {
+    flb_plg_info(ctx->ins,
+                      "get meta info from request is called");
     struct flb_http_client *c;
     struct flb_upstream_conn *u_conn;
     int ret;
@@ -430,6 +545,9 @@ static int get_meta_info_from_request(struct flb_filter_aws *ctx,
         return -1;
     }
 
+    /* Buffer size for HTTP Client when reading responses from API Server */
+    ctx->buffer_size = 32000;
+
     /* Compose HTTP Client request*/
     c = flb_http_client(u_conn, FLB_HTTP_GET,
                         uri,
@@ -443,7 +561,7 @@ static int get_meta_info_from_request(struct flb_filter_aws *ctx,
     }
 
     ret = flb_http_do(c, &b_sent);
-    flb_plg_debug(ctx->ins, "Request (ns=%s, %s=%s) http_do=%i, "
+    flb_plg_info(ctx->ins, "Request (ns=%s, %s=%s) http_do=%i, "
                   "HTTP Status: %i",
                   namespace, resource_type, resource_name, ret, c->resp.status);
 
@@ -473,6 +591,8 @@ static int get_api_server_configmap(struct flb_filter_aws *ctx,
                                const char *namespace, const char *configmap,
                                char **out_buf, size_t *out_size)
 {
+    flb_plg_info(ctx->ins,
+                      "get API Server for configmap information");
     int ret;
     int packed = -1;
     int root_type;
@@ -491,7 +611,7 @@ static int get_api_server_configmap(struct flb_filter_aws *ctx,
         if (ret == -1) {
             return -1;
         }
-        flb_plg_debug(ctx->ins,
+        flb_plg_info(ctx->ins,
                       "Send out request to API Server for configmap information");
         packed = get_meta_info_from_request(ctx,ctx->kubernetes_upstream, namespace,FLB_KUBE_CONFIGMAP, configmap,
                                     &buf, &size, &root_type, uri);
@@ -511,18 +631,19 @@ static int get_api_server_configmap(struct flb_filter_aws *ctx,
 static void get_platform(struct flb_filter_aws *ctx)
 {
     if (ctx->platform == NULL) {
-      char *config_buf = NULL;
-    size_t config_size;
-    ret = get_api_server_configmap(ctx, KUBE_SYSTEM_NAMESPACE,AWS_AUTH_CONFIG_MAP,
-                               &config_buf, &config_size);
-    if (ret == -1) {
-        ctx->platform = flb_strdup(NATIVE_KUBERNETES_PLATFORM);
-    } else {
-        ctx->platform = flb_strdup(EKS_PLATFORM);
-    }
-    ctx->platform_len = strlen(ctx->platform);
-    ctx->new_keys++;
-    flb_plg_debug(ctx->ins, "Platform type is %s.", ctx->platform);
+        char *config_buf = NULL;
+        size_t config_size;
+        int ret;
+        ret = get_api_server_configmap(ctx, KUBE_SYSTEM_NAMESPACE,AWS_AUTH_CONFIG_MAP,
+                                &config_buf, &config_size);
+        if (ret == -1) {
+            ctx->platform = flb_strdup(NATIVE_KUBERNETES_PLATFORM);
+        } else {
+            ctx->platform = flb_strdup(EKS_PLATFORM);
+        }
+        ctx->platform_len = strlen(ctx->platform);
+        ctx->new_keys++;
+        flb_plg_info(ctx->ins, "Platform type is %s.", ctx->platform);
     }
 }
 
@@ -651,8 +772,9 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
       }
 
       if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
-        get_cluster_from_environment(ctx)
-        get_platform(ctx)
+        flb_plg_info(ctx->ins, "getting cluster name and platform in aws plugin");
+        get_cluster_from_environment(ctx);
+        get_platform(ctx);
       }
       // new keys for entity type field which should be added to message pack
       ctx->new_keys++;
@@ -820,6 +942,8 @@ static int cb_aws_filter(const void *data, size_t bytes,
         }
 
         if (ctx->enable_entity && ctx->instance_id != NULL && ctx->account_id != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
+            flb_plg_info(ctx->ins,
+                      "Adding instance id and account id to message pack");
             // Pack instance ID with entity prefix for further processing
             msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
             msgpack_pack_str_body(&tmp_pck,
@@ -842,18 +966,20 @@ static int cb_aws_filter(const void *data, size_t bytes,
             msgpack_pack_str_body(&tmp_pck,
                                   FLB_FILTER_AWS_ENTITY_TYPE_KEY,
                                   FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, ctx->entity_type);
+            msgpack_pack_str(&tmp_pck, strlen(ctx->entity_type));
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->entity_type, strlen(ctx->entity_type));
         }
 
         if (ctx->enable_entity && ctx->cluster !=NULL && ctx->platform != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 ) {
-          // Pack cluster name with entity prefix for further processing
+            flb_plg_info(ctx->ins,
+                      "Adding cluster name and type to message pack");
+            // Pack cluster name with entity prefix for further processing
             msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN);
             msgpack_pack_str_body(&tmp_pck,
                                   FLB_FILTER_AWS_ENTITY_CLUSTER_KEY,
                                   FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, ctx->cluster);
+            msgpack_pack_str(&tmp_pck, ctx->cluster_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->cluster, ctx->cluster_len);
            // Pack platform with entity prefix for further processing
@@ -861,7 +987,7 @@ static int cb_aws_filter(const void *data, size_t bytes,
             msgpack_pack_str_body(&tmp_pck,
                                   FLB_FILTER_AWS_ENTITY_PLATFORM_KEY,
                                   FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, ctx->platform);
+            msgpack_pack_str(&tmp_pck, ctx->platform_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->platform, ctx->platform_len);
             // Pack entity type with entity prefix for further processing
@@ -869,7 +995,7 @@ static int cb_aws_filter(const void *data, size_t bytes,
             msgpack_pack_str_body(&tmp_pck,
                                   FLB_FILTER_AWS_ENTITY_TYPE_KEY,
                                   FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
-            msgpack_pack_str(&tmp_pck, ctx->entity_type);
+            msgpack_pack_str(&tmp_pck, strlen(ctx->entity_type));
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->entity_type, strlen(ctx->entity_type));
         }
@@ -935,6 +1061,10 @@ static void flb_filter_aws_destroy(struct flb_filter_aws *ctx)
 
     if(ctx->platform) {
       flb_sds_destroy(ctx->platform);
+    }
+
+    if(ctx->entity_type){
+        flb_sds_destroy(ctx->entity_type);
     }
     flb_free(ctx);
 }
@@ -1005,10 +1135,15 @@ static struct flb_config_map config_map[] = {
     "This currently only affects instance ID"
     },
     {
-    FLB_CONFIG_MAP_STR, "entity_type", "Service",
+    FLB_CONFIG_MAP_STR, "entity_type", "service",
     0, FLB_TRUE, offsetof(struct flb_filter_aws, entity_type),
     "Defines the type of entity and adds related entity fields"
     "Possible values Service or Resource"
+    },
+    {
+     FLB_CONFIG_MAP_TIME, "kube_token_ttl", "10m",
+     0, FLB_TRUE, offsetof(struct flb_filter_aws, kube_token_ttl),
+     "kubernetes token ttl, until it is reread from the token file. Default: 10m"
     },
     {0}
 };

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -115,7 +115,7 @@ static void create_kubernetes_upstream(struct flb_filter_aws *ctx, struct flb_co
                                   ctx->tls_ca_file,
                                   NULL, NULL, NULL);
     if (!ctx->tls) {
-        flb_plg_error(ctx->ins, "tls creation failed in creating k8s upstream");
+        flb_plg_error(ctx->ins, "tls creation failed in creating k8s upstream in aws plugin");
     }
 
     /* Create an Upstream context */
@@ -124,9 +124,8 @@ static void create_kubernetes_upstream(struct flb_filter_aws *ctx, struct flb_co
                                     FLB_API_PORT,
                                     FLB_IO_TLS,
                                     ctx->tls);
-    flb_plg_info(ctx->ins, "kubernetes upstream connection created in aws plugin");
     if (!ctx->kubernetes_upstream) {
-        flb_plg_info(ctx->ins, "kubernetes upstream connection initialization error in aws plugin");
+        flb_plg_error(ctx->ins, "kubernetes upstream connection initialization error in aws plugin");
     }
 }
 
@@ -412,7 +411,7 @@ static void get_cluster_from_environment(struct flb_filter_aws *ctx)
         } else {
             free(cluster_name);
         }
-        flb_plg_info(ctx->ins, "Cluster name is %s.", ctx->cluster);
+        flb_plg_debug(ctx->ins, "Cluster name is %s.", ctx->cluster);
     }
 }
 
@@ -539,8 +538,6 @@ static int get_meta_info_from_request(struct flb_filter_aws *ctx,
                                       int *root_type,
                                       char* uri)
 {
-    flb_plg_info(ctx->ins,
-                      "get meta info from request is called");
     struct flb_http_client *c;
     struct flb_upstream_conn *u_conn;
     int ret;
@@ -577,7 +574,7 @@ static int get_meta_info_from_request(struct flb_filter_aws *ctx,
     }
 
     ret = flb_http_do(c, &b_sent);
-    flb_plg_info(ctx->ins, "Request (ns=%s, %s=%s) http_do=%i, "
+    flb_plg_debug(ctx->ins, "Request (ns=%s, %s=%s) http_do=%i, "
                   "HTTP Status: %i",
                   namespace, resource_type, resource_name, ret, c->resp.status);
 
@@ -607,8 +604,6 @@ static int get_api_server_configmap(struct flb_filter_aws *ctx,
                                const char *namespace, const char *configmap,
                                char **out_buf, size_t *out_size)
 {
-    flb_plg_info(ctx->ins,
-                      "get API Server for configmap information");
     int ret;
     int packed = -1;
     int root_type;
@@ -627,8 +622,8 @@ static int get_api_server_configmap(struct flb_filter_aws *ctx,
         if (ret == -1) {
             return -1;
         }
-        flb_plg_info(ctx->ins,
-                      "Send out request to API Server for configmap information");
+        flb_plg_debug(ctx->ins,
+                      "Send out request to API Server for configmap information in aws plugin");
         packed = get_meta_info_from_request(ctx,ctx->kubernetes_upstream, namespace,FLB_KUBE_CONFIGMAP, configmap,
                                     &buf, &size, &root_type, uri);
     }
@@ -659,7 +654,7 @@ static void get_platform(struct flb_filter_aws *ctx)
         }
         ctx->platform_len = strlen(ctx->platform);
         ctx->new_keys++;
-        flb_plg_info(ctx->ins, "Platform type is %s.", ctx->platform);
+        flb_plg_debug(ctx->ins, "Platform type is %s.", ctx->platform);
     }
 }
 
@@ -786,7 +781,8 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
             ctx->new_keys++;
         }
       }
-
+      ctx->cluster = NULL;
+      ctx->platform = NULL;
       if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
         get_cluster_from_environment(ctx);
         get_platform(ctx);
@@ -1042,6 +1038,10 @@ static void flb_filter_aws_destroy(struct flb_filter_aws *ctx)
 
     if (ctx->hostname) {
         flb_sds_destroy(ctx->hostname);
+    }
+
+    if(ctx->tls) {
+        flb_tls_destroy(ctx->tls);
     }
 
     if(ctx->kubernetes_upstream) {

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -179,6 +179,16 @@ static int cb_aws_init(struct flb_filter_instance *f_ins,
         expose_aws_meta(ctx);
     }
 
+    if (ctx->enable_entity && strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
+       ctx->kubernetes_upstream = flb_upstream_create(config,
+                                    FLB_API_HOST,
+                                    FLB_API_PORT,
+                                    FLB_IO_TLS,
+                                    NULL);
+    }
+    if (!ctx->kubernetes_upstream) {
+        flb_plg_debug(ctx->ins, "kubernetes upstream connection initialization error in aws plugin");
+    }
     flb_filter_set_context(f_ins, ctx);
     return 0;
 }
@@ -370,6 +380,152 @@ static int get_vpc_metadata(struct flb_filter_aws *ctx)
     return ret;
 }
 
+static void get_cluster_from_environment(struct flb_filter_aws *ctx)
+{
+    if(ctx->cluster == NULL) {
+        char* cluster_name = getenv("CLUSTER_NAME");
+        if(cluster_name) {
+            ctx->cluster = strdup(cluster_name);
+            ctx->cluster_len = strlen(cluster_name);
+            ctx->new_keys++;
+        } else {
+            free(cluster_name);
+        }
+        flb_plg_debug(ctx->ins, "Cluster name is %s.", ctx->cluster);
+    }
+}
+
+/* Gather metadata from HTTP Request,
+ * this could send out HTTP Request either to KUBE Server API or Kubelet
+ */
+static int get_meta_info_from_request(struct flb_filter_aws *ctx,
+                                      struct flb_upstream *upstream,
+                                      const char *namespace,
+                                      const char *resource_type,
+                                      const char *resource_name,
+                                      char **buffer, size_t *size,
+                                      int *root_type,
+                                      char* uri)
+{
+    struct flb_http_client *c;
+    struct flb_upstream_conn *u_conn;
+    int ret;
+    size_t b_sent;
+    int packed;
+
+    if (!upstream) {
+        return -1;
+    }
+
+    u_conn = flb_upstream_conn_get(upstream);
+
+    if (!u_conn) {
+        flb_plg_error(ctx->ins, "kubelet upstream connection error");
+        return -1;
+    }
+
+    ret = refresh_token_if_needed(ctx);
+    if (ret == -1) {
+        flb_plg_error(ctx->ins, "failed to refresh token");
+        return -1;
+    }
+
+    /* Compose HTTP Client request*/
+    c = flb_http_client(u_conn, FLB_HTTP_GET,
+                        uri,
+                        NULL, 0, NULL, 0, NULL, 0);
+    flb_http_buffer_size(c, ctx->buffer_size);
+
+    flb_http_add_header(c, "User-Agent", 10, "Fluent-Bit", 10);
+    flb_http_add_header(c, "Connection", 10, "close", 5);
+    if (ctx->auth_len > 0) {
+        flb_http_add_header(c, "Authorization", 13, ctx->auth, ctx->auth_len);
+    }
+
+    ret = flb_http_do(c, &b_sent);
+    flb_plg_debug(ctx->ins, "Request (ns=%s, %s=%s) http_do=%i, "
+                  "HTTP Status: %i",
+                  namespace, resource_type, resource_name, ret, c->resp.status);
+
+    if (ret != 0 || c->resp.status != 200) {
+        if (c->resp.payload_size > 0) {
+            flb_plg_debug(ctx->ins, "HTTP response\n%s",
+                          c->resp.payload);
+        }
+        flb_http_client_destroy(c);
+        flb_upstream_conn_release(u_conn);
+        return -1;
+    }
+
+    packed = flb_pack_json(c->resp.payload, c->resp.payload_size,
+                                   buffer, size, root_type);
+
+    /* release resources */
+    flb_http_client_destroy(c);
+    flb_upstream_conn_release(u_conn);
+
+    return packed;
+
+}
+
+/* Gather metadata from API Server */
+static int get_api_server_configmap(struct flb_filter_aws *ctx,
+                               const char *namespace, const char *configmap,
+                               char **out_buf, size_t *out_size)
+{
+    int ret;
+    int packed = -1;
+    int root_type;
+    char uri[1024];
+    char *buf;
+    size_t size;
+
+    *out_buf = NULL;
+    *out_size = 0;
+
+    if (packed == -1) {
+
+        ret = snprintf(uri, sizeof(uri) - 1, FLB_KUBE_API_CONFIGMAP_FMT, namespace,
+                       configmap);
+
+        if (ret == -1) {
+            return -1;
+        }
+        flb_plg_debug(ctx->ins,
+                      "Send out request to API Server for configmap information");
+        packed = get_meta_info_from_request(ctx,ctx->kubernetes_upstream, namespace,FLB_KUBE_CONFIGMAP, configmap,
+                                    &buf, &size, &root_type, uri);
+    }
+
+    /* validate pack */
+    if (packed == -1) {
+        return -1;
+    }
+
+    *out_buf = buf;
+    *out_size = size;
+
+    return 0;
+}
+
+static void get_platform(struct flb_filter_aws *ctx)
+{
+    if (ctx->platform == NULL) {
+      char *config_buf = NULL;
+    size_t config_size;
+    ret = get_api_server_configmap(ctx, KUBE_SYSTEM_NAMESPACE,AWS_AUTH_CONFIG_MAP,
+                               &config_buf, &config_size);
+    if (ret == -1) {
+        ctx->platform = flb_strdup(NATIVE_KUBERNETES_PLATFORM);
+    } else {
+        ctx->platform = flb_strdup(EKS_PLATFORM);
+    }
+    ctx->platform_len = strlen(ctx->platform);
+    ctx->new_keys++;
+    flb_plg_debug(ctx->ins, "Platform type is %s.", ctx->platform);
+    }
+}
+
 /*
  * Makes a call to IMDS to set get the values of all metadata fields.
  * It can be called repeatedly if some metadata calls initially do not succeed.
@@ -468,6 +624,7 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
     }
 
     if (ctx->enable_entity) {
+      if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
         if (!ctx->account_id) {
             ret = get_metadata_by_key(ctx, FLB_FILTER_AWS_IMDS_ACCOUNT_ID_PATH,
                                   &ctx->account_id, &ctx->account_id_len,
@@ -491,6 +648,14 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
         } else {
             ctx->new_keys++;
         }
+      }
+
+      if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
+        get_cluster_from_environment(ctx)
+        get_platform(ctx)
+      }
+      // new keys for entity type field which should be added to message pack
+      ctx->new_keys++;
     }
 
     ctx->metadata_retrieved = FLB_TRUE;
@@ -654,7 +819,7 @@ static int cb_aws_filter(const void *data, size_t bytes,
                                   ctx->hostname, ctx->hostname_len);
         }
 
-        if (ctx->enable_entity && ctx->instance_id != NULL && ctx->account_id != NULL) {
+        if (ctx->enable_entity && ctx->instance_id != NULL && ctx->account_id != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
             // Pack instance ID with entity prefix for further processing
             msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_INSTANCE_ID_KEY_LEN);
             msgpack_pack_str_body(&tmp_pck,
@@ -672,7 +837,43 @@ static int cb_aws_filter(const void *data, size_t bytes,
             msgpack_pack_str(&tmp_pck, ctx->account_id_len);
             msgpack_pack_str_body(&tmp_pck,
                                   ctx->account_id, ctx->account_id_len);
+            // Pack entity type with entity prefix for further processing
+            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
+            msgpack_pack_str_body(&tmp_pck,
+                                  FLB_FILTER_AWS_ENTITY_TYPE_KEY,
+                                  FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
+            msgpack_pack_str(&tmp_pck, ctx->entity_type);
+            msgpack_pack_str_body(&tmp_pck,
+                                  ctx->entity_type, strlen(ctx->entity_type));
         }
+
+        if (ctx->enable_entity && ctx->cluster !=NULL && ctx->platform != NULL && strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 ) {
+          // Pack cluster name with entity prefix for further processing
+            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN);
+            msgpack_pack_str_body(&tmp_pck,
+                                  FLB_FILTER_AWS_ENTITY_CLUSTER_KEY,
+                                  FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN);
+            msgpack_pack_str(&tmp_pck, ctx->cluster);
+            msgpack_pack_str_body(&tmp_pck,
+                                  ctx->cluster, ctx->cluster_len);
+           // Pack platform with entity prefix for further processing
+            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN);
+            msgpack_pack_str_body(&tmp_pck,
+                                  FLB_FILTER_AWS_ENTITY_PLATFORM_KEY,
+                                  FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN);
+            msgpack_pack_str(&tmp_pck, ctx->platform);
+            msgpack_pack_str_body(&tmp_pck,
+                                  ctx->platform, ctx->platform_len);
+            // Pack entity type with entity prefix for further processing
+            msgpack_pack_str(&tmp_pck, FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
+            msgpack_pack_str_body(&tmp_pck,
+                                  FLB_FILTER_AWS_ENTITY_TYPE_KEY,
+                                  FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN);
+            msgpack_pack_str(&tmp_pck, ctx->entity_type);
+            msgpack_pack_str_body(&tmp_pck,
+                                  ctx->entity_type, strlen(ctx->entity_type));
+        }
+
     }
     msgpack_unpacked_destroy(&result);
 
@@ -724,6 +925,17 @@ static void flb_filter_aws_destroy(struct flb_filter_aws *ctx)
         flb_sds_destroy(ctx->hostname);
     }
 
+    if(ctx->kubernetes_upstream) {
+      flb_upstream_destroy(ctx->kubernetes_upstream);
+    }
+
+    if(ctx->cluster) {
+      flb_sds_destroy(ctx->cluster);
+    }
+
+    if(ctx->platform) {
+      flb_sds_destroy(ctx->platform);
+    }
     flb_free(ctx);
 }
 
@@ -791,6 +1003,12 @@ static struct flb_config_map config_map[] = {
     0, FLB_TRUE, offsetof(struct flb_filter_aws, enable_entity),
     "Enable entity prefix for fields used for constructing entity."
     "This currently only affects instance ID"
+    },
+    {
+    FLB_CONFIG_MAP_STR, "entity_type", "Service",
+    0, FLB_TRUE, offsetof(struct flb_filter_aws, entity_type),
+    "Defines the type of entity and adds related entity fields"
+    "Possible values Service or Resource"
     },
     {0}
 };

--- a/plugins/filter_aws/aws.c
+++ b/plugins/filter_aws/aws.c
@@ -759,7 +759,6 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
     }
 
     if (ctx->enable_entity) {
-      if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
         if (!ctx->account_id) {
             ret = get_metadata_by_key(ctx, FLB_FILTER_AWS_IMDS_ACCOUNT_ID_PATH,
                                   &ctx->account_id, &ctx->account_id_len,
@@ -771,7 +770,7 @@ static int get_ec2_metadata(struct flb_filter_aws *ctx)
         } else {
             ctx->new_keys++;
         }
-
+      if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
         if (!ctx->instance_id) {
             ret = get_metadata(ctx, FLB_FILTER_AWS_IMDS_INSTANCE_ID_PATH,
                    &ctx->instance_id, &ctx->instance_id_len);

--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -67,20 +67,20 @@
 #define FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN          21
 #define FLB_FILTER_AWS_HOSTNAME_KEY                       "hostname"
 #define FLB_FILTER_AWS_HOSTNAME_KEY_LEN                   8
-#define FLB_FILTER_AWS_ENTITY_PLATFORM_KEY             "aws_entity_platform"
-#define FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN         19
-#define FLB_FILTER_AWS_ENTITY_CLUSTER_KEY             "aws_entity_cluster"
-#define FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN         18
-#define FLB_FILTER_AWS_ENTITY_TYPE_KEY             "aws_entity_type"
-#define FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN         15
+#define FLB_FILTER_AWS_ENTITY_PLATFORM_KEY                "aws_entity_platform"
+#define FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN            19
+#define FLB_FILTER_AWS_ENTITY_CLUSTER_KEY                 "aws_entity_cluster"
+#define FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN             18
+#define FLB_FILTER_AWS_ENTITY_TYPE_KEY                    "aws_entity_type"
+#define FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN                15
 
 /*
  * Possible entity type values for aws plugin
  */
 #define FLB_FILTER_ENTITY_TYPE_RESOURCE                   "resource"
-#define FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN                8
-#define FLB_FILTER_ENTITY_TYPE_SERVICE                "service"
-#define FLB_FILTER_ENTITY_TYPE_SERVICE_LEN              7
+#define FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN               8
+#define FLB_FILTER_ENTITY_TYPE_SERVICE                    "service"
+#define FLB_FILTER_ENTITY_TYPE_SERVICE_LEN                7
 /*
  * Possible platform values for aws plugin
  */
@@ -98,6 +98,10 @@
 #define FLB_API_HOST  "kubernetes.default.svc"
 #define FLB_API_PORT  443
 #define FLB_API_TLS   FLB_TRUE
+
+#define FLB_KUBE_TOKEN "/var/run/secrets/kubernetes.io/serviceaccount/token"
+#define FLB_KUBE_CONFIGMAP "configmap"
+#define FLB_KUBE_API_CONFIGMAP_FMT "/api/v1/namespaces/%s/configmaps/%s"
 
 struct flb_filter_aws {
     /* upstream connection to ec2 IMDS */
@@ -157,7 +161,6 @@ struct flb_filter_aws {
     * Possible values resource or service
     */
     flb_sds_t entity_type;
-    si
 
     char *cluster;
     int cluster_len;
@@ -183,6 +186,22 @@ struct flb_filter_aws {
 
     /* Filter plugin instance reference */
     struct flb_filter_instance *ins;
+
+    /* HTTP Client Setup */
+    size_t buffer_size;
+
+    /* Pre-formatted HTTP Authorization header value */
+    char *auth;
+    size_t auth_len;
+
+    /* Command to get Kubernetes Authorization Token */
+    const char *kube_token_command; 
+    int kube_token_create;
+    int kube_token_ttl;
+
+    /* Kubernetes Token from FLB_KUBE_TOKEN file */
+    char *token;
+    size_t token_len;
 };
 
 #endif

--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -71,8 +71,6 @@
 #define FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN            19
 #define FLB_FILTER_AWS_ENTITY_CLUSTER_KEY                 "aws_entity_cluster"
 #define FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN             18
-#define FLB_FILTER_AWS_ENTITY_TYPE_KEY                    "aws_entity_type"
-#define FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN                15
 
 /*
  * Possible entity type values for aws plugin
@@ -82,7 +80,7 @@
 #define FLB_FILTER_ENTITY_TYPE_SERVICE                    "service"
 #define FLB_FILTER_ENTITY_TYPE_SERVICE_LEN                7
 /*
- * Possible platform values for aws plugin
+ * Possible cluster platform values for aws plugin
  */
 #define NATIVE_KUBERNETES_PLATFORM "k8s"
 #define EKS_PLATFORM "eks"

--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -67,6 +67,37 @@
 #define FLB_FILTER_AWS_ENTITY_ACCOUNT_ID_KEY_LEN          21
 #define FLB_FILTER_AWS_HOSTNAME_KEY                       "hostname"
 #define FLB_FILTER_AWS_HOSTNAME_KEY_LEN                   8
+#define FLB_FILTER_AWS_ENTITY_PLATFORM_KEY             "aws_entity_platform"
+#define FLB_FILTER_AWS_ENTITY_PLATFORM_KEY_LEN         19
+#define FLB_FILTER_AWS_ENTITY_CLUSTER_KEY             "aws_entity_cluster"
+#define FLB_FILTER_AWS_ENTITY_CLUSTER_KEY_LEN         18
+#define FLB_FILTER_AWS_ENTITY_TYPE_KEY             "aws_entity_type"
+#define FLB_FILTER_AWS_ENTITY_TYPE_KEY_LEN         15
+
+/*
+ * Possible entity type values for aws plugin
+ */
+#define FLB_FILTER_ENTITY_TYPE_RESOURCE                   "resource"
+#define FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN                8
+#define FLB_FILTER_ENTITY_TYPE_SERVICE                "service"
+#define FLB_FILTER_ENTITY_TYPE_SERVICE_LEN              7
+/*
+ * Possible platform values for aws plugin
+ */
+#define NATIVE_KUBERNETES_PLATFORM "k8s"
+#define EKS_PLATFORM "eks"
+
+/*
+ * Configmap used for verifying whether if FluentBit is
+ * on EKS or native Kubernetes
+ */
+#define KUBE_SYSTEM_NAMESPACE "kube-system"
+#define AWS_AUTH_CONFIG_MAP "aws-auth"
+
+/* Kubernetes API server info */
+#define FLB_API_HOST  "kubernetes.default.svc"
+#define FLB_API_PORT  443
+#define FLB_API_TLS   FLB_TRUE
 
 struct flb_filter_aws {
     /* upstream connection to ec2 IMDS */
@@ -120,6 +151,27 @@ struct flb_filter_aws {
     * 'aws_entity' to relevant keys
     */
     int enable_entity;
+
+    /*
+    * Defines the type of entity.
+    * Possible values resource or service
+    */
+    flb_sds_t entity_type;
+    si
+
+    char *cluster;
+    int cluster_len;
+    char *platform;
+    int platform_len;
+
+    /*
+     * This connection is used for calling Kubernetes configmaps
+     * endpoint so pod association can determine the environment.
+     * Example: EKS or Native Kubernetes.
+     */
+    char *kubernetes_api_host;
+    int kubernetes_api_port;
+    struct flb_upstream *kubernetes_upstream;
 
     /* number of new keys added by this plugin */
     int new_keys;

--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -100,6 +100,7 @@
 #define FLB_API_TLS   FLB_TRUE
 
 #define FLB_KUBE_TOKEN "/var/run/secrets/kubernetes.io/serviceaccount/token"
+#define FLB_KUBE_CA "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 #define FLB_KUBE_CONFIGMAP "configmap"
 #define FLB_KUBE_API_CONFIGMAP_FMT "/api/v1/namespaces/%s/configmaps/%s"
 
@@ -202,6 +203,17 @@ struct flb_filter_aws {
     /* Kubernetes Token from FLB_KUBE_TOKEN file */
     char *token;
     size_t token_len;
+
+    struct flb_tls *tls;
+
+    /* TLS CA certificate file */
+    char *tls_ca_path;
+    char *tls_ca_file;
+    int tls_debug;
+    int tls_verify;
+    /* TLS virtual host (optional), set by configmap */
+    flb_sds_t tls_vhost;
+
 };
 
 #endif

--- a/plugins/filter_aws/aws.h
+++ b/plugins/filter_aws/aws.h
@@ -171,8 +171,6 @@ struct flb_filter_aws {
      * endpoint so pod association can determine the environment.
      * Example: EKS or Native Kubernetes.
      */
-    char *kubernetes_api_host;
-    int kubernetes_api_port;
     struct flb_upstream *kubernetes_upstream;
 
     /* number of new keys added by this plugin */
@@ -194,7 +192,6 @@ struct flb_filter_aws {
     size_t auth_len;
 
     /* Command to get Kubernetes Authorization Token */
-    const char *kube_token_command; 
     int kube_token_create;
     int kube_token_ttl;
 

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -239,7 +239,6 @@ error:
 }
 
 static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct cw_flush *buf, struct log_stream *stream, int *offset) {
-    flb_plg_info(ctx->ins, "entity_add_resource_key_attributes is called");
     char ts[KEY_ATTRIBUTES_MAX_LEN];
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
                       "\"keyAttributes\":{",0)) {
@@ -250,9 +249,7 @@ static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct
         goto error;
     }
     if(stream->entity->key_attributes->platform != NULL && strlen(stream->entity->key_attributes->platform) != 0) {
-        flb_plg_info(ctx->ins, "stream entity resource platform %s", stream->entity->key_attributes->platform);
         if (strncmp(stream->entity->key_attributes->platform, EKS_PLATFORM, 3) == 0) {
-            flb_plg_info(ctx->ins, "setting platform to eks %s", stream->entity->key_attributes->platform);
             if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"ResourceType\":\"","AWS::EKS::Cluster","\"")) {
                 goto error;
             }
@@ -456,7 +453,6 @@ static int init_put_payload(struct flb_cloudwatch *ctx, struct cw_flush *buf,
                       "\"logEvents\":[", 13)) {
         goto error;
     }
-    flb_plg_info(ctx->ins, "entity %s", buf->out_buf);
 
     return 0;
 
@@ -811,7 +807,7 @@ retry:
         return -1;
     }
 
-    flb_plg_info(ctx->ins, "cloudwatch:PutLogEvents: events=%d, payload=%d bytes", i, offset);
+    flb_plg_debug(ctx->ins, "cloudwatch:PutLogEvents: events=%d, payload=%d bytes", i, offset);
     ret = put_log_events(ctx, buf, buf->current_stream, (size_t) offset);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Failed to send log events");
@@ -1190,7 +1186,6 @@ void parse_entity(struct flb_cloudwatch *ctx, entity *entity, msgpack_object map
                 flb_free(entity->key_attributes->platform);
             }
             entity->key_attributes->platform = flb_strndup(val.via.str.ptr, val.via.str.size);
-            flb_plg_info(ctx->ins,"entity platform is added %s", entity->key_attributes->platform);
         }
         if(strncmp(key.via.str.ptr, "aws_entity_cluster",key.via.str.size ) == 0 ) {
             if(entity->key_attributes->cluster_name == NULL) {
@@ -1199,7 +1194,6 @@ void parse_entity(struct flb_cloudwatch *ctx, entity *entity, msgpack_object map
                 flb_free(entity->key_attributes->cluster_name);
             }
             entity->key_attributes->cluster_name = flb_strndup(val.via.str.ptr, val.via.str.size);
-            flb_plg_info(ctx->ins,"entity cluster name is added %s", entity->key_attributes->cluster_name);
         }
     }
     if (strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
@@ -1334,9 +1328,6 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
             update_or_create_entity(ctx,stream,map);
             // Prepare a buffer to pack the modified map
             if(stream->entity != NULL && (stream->entity->root_filter_count > 0 || stream->entity->filter_count > 0)) {
-                if (strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
-                    flb_plg_info(ctx->ins, "stream->entity->root_filter_count %d", stream->entity->root_filter_count);
-                }
                 msgpack_packer pk;
                 msgpack_packer_init(&pk, &filtered_sbuf, msgpack_sbuffer_write);
                 remove_unneeded_field(&map, "kubernetes",&pk,stream->entity->root_filter_count, stream->entity->filter_count);
@@ -1896,8 +1887,7 @@ int put_log_events(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     int num_headers = 1;
     int retry = FLB_TRUE;
 
-    flb_plg_info(ctx->ins, "Sending log events to log stream %s", stream->name);
-    flb_plg_info(ctx->ins, "data buf %s", buf->out_buf);
+    flb_plg_debug(ctx->ins, "Sending log events to log stream %s", stream->name);
 
     /* stream is being used, update expiration */
     stream->expiration = time(NULL) + FOUR_HOURS_IN_SECONDS;
@@ -1920,9 +1910,9 @@ retry_request:
     }
 
     if (c) {
-        flb_plg_info(ctx->ins, "PutLogEvents http status=%d", c->resp.status);
-        flb_plg_info(ctx->ins, "PutLogEvents http data=%s", c->resp.data);
-        flb_plg_info(ctx->ins, "PutLogEvents http payload=%s", c->resp.payload);
+        flb_plg_debug(ctx->ins, "PutLogEvents http status=%d", c->resp.status);
+        flb_plg_debug(ctx->ins, "PutLogEvents http data=%s", c->resp.data);
+        flb_plg_debug(ctx->ins, "PutLogEvents http payload=%s", c->resp.payload);
 
         if (c->resp.status == 200) {
             if (c->resp.data == NULL || c->resp.data_len == 0 || strstr(c->resp.data, AMZN_REQUEST_ID_HEADER) == NULL) {

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -239,6 +239,7 @@ error:
 }
 
 static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct cw_flush *buf, struct log_stream *stream, int *offset) {
+    flb_plg_info(ctx->ins, "entity_add_resource_key_attributes is called");
     char ts[KEY_ATTRIBUTES_MAX_LEN];
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
                       "\"keyAttributes\":{",0)) {
@@ -249,14 +250,16 @@ static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct
         goto error;
     }
     if(stream->entity->key_attributes->platform != NULL && strlen(stream->entity->key_attributes->platform) != 0) {
-        if (strncmp(stream->entity->key_attributes->platform, EKS_PLATFORM, 3)) {
+        flb_plg_info(ctx->ins, "stream entity resource platform %s", stream->entity->key_attributes->platform);
+        if (strncmp(stream->entity->key_attributes->platform, EKS_PLATFORM, 3) == 0) {
+            flb_plg_info(ctx->ins, "setting platform to eks %s", stream->entity->key_attributes->platform);
             if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"ResourceType\":\"","AWS::EKS::Cluster","\"")) {
                 goto error;
             }
             if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,ts,0)) {
                 goto error;
             }
-        } else if (strncmp(stream->entity->key_attributes->platform, NATIVE_KUBERNETES_PLATFORM, 3)) {
+        } else if (strncmp(stream->entity->key_attributes->platform, NATIVE_KUBERNETES_PLATFORM, 3) == 0) {
             if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"ResourceType\":\"","K8s::Cluster","\"")) {
                 goto error;
             }
@@ -274,7 +277,7 @@ static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct
         }
     }
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-              "},", 2)) {
+              "}", 1)) {
         goto error;
     }
     return 0;
@@ -418,7 +421,7 @@ static int init_put_payload(struct flb_cloudwatch *ctx, struct cw_flush *buf,
                         "\"entity\":{", 10)) {
                 goto error;
         }
-        if (strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
+        if (strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 && stream->entity->key_attributes->platform != NULL && stream->entity->key_attributes->cluster_name != NULL) {
             if(stream->entity->key_attributes != NULL) {
                 ret = entity_add_resource_key_attributes(ctx,buf,stream,offset);
                 if (ret < 0) {
@@ -448,12 +451,12 @@ static int init_put_payload(struct flb_cloudwatch *ctx, struct cw_flush *buf,
                 goto error;
         }
     }
-    
 
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
                       "\"logEvents\":[", 13)) {
         goto error;
     }
+    flb_plg_info(ctx->ins, "entity %s", buf->out_buf);
 
     return 0;
 
@@ -808,7 +811,7 @@ retry:
         return -1;
     }
 
-    flb_plg_debug(ctx->ins, "cloudwatch:PutLogEvents: events=%d, payload=%d bytes", i, offset);
+    flb_plg_info(ctx->ins, "cloudwatch:PutLogEvents: events=%d, payload=%d bytes", i, offset);
     ret = put_log_events(ctx, buf, buf->current_stream, (size_t) offset);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Failed to send log events");
@@ -1187,6 +1190,7 @@ void parse_entity(struct flb_cloudwatch *ctx, entity *entity, msgpack_object map
                 flb_free(entity->key_attributes->platform);
             }
             entity->key_attributes->platform = flb_strndup(val.via.str.ptr, val.via.str.size);
+            flb_plg_info(ctx->ins,"entity platform is added %s", entity->key_attributes->platform);
         }
         if(strncmp(key.via.str.ptr, "aws_entity_cluster",key.via.str.size ) == 0 ) {
             if(entity->key_attributes->cluster_name == NULL) {
@@ -1195,14 +1199,17 @@ void parse_entity(struct flb_cloudwatch *ctx, entity *entity, msgpack_object map
                 flb_free(entity->key_attributes->cluster_name);
             }
             entity->key_attributes->cluster_name = flb_strndup(val.via.str.ptr, val.via.str.size);
+            flb_plg_info(ctx->ins,"entity cluster name is added %s", entity->key_attributes->cluster_name);
         }
     }
-    if(entity->key_attributes->name == NULL && entity->attributes->name_source == NULL &&entity->attributes->workload != NULL) {
-        entity->key_attributes->name = flb_strndup(entity->attributes->workload, strlen(entity->attributes->workload));
-        entity->attributes->name_source = flb_strndup("K8sWorkload", 11);
-    }
-    if(entity->key_attributes->environment == NULL) {
-        entity->key_attributes->environment = find_fallback_environment(ctx, entity);
+    if (strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
+        if(entity->key_attributes->name == NULL && entity->attributes->name_source == NULL &&entity->attributes->workload != NULL) {
+            entity->key_attributes->name = flb_strndup(entity->attributes->workload, strlen(entity->attributes->workload));
+            entity->attributes->name_source = flb_strndup("K8sWorkload", 11);
+        }
+        if(entity->key_attributes->environment == NULL) {
+            entity->key_attributes->environment = find_fallback_environment(ctx, entity);
+        }
     }
 }
 
@@ -1314,7 +1321,7 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
         map = root.via.array.ptr[1];
         map_size = map.via.map.size;
 
-        if(ctx->kubernete_metadata_enabled && ctx->add_entity) {
+        if( ctx->add_entity && ( ctx->kubernete_metadata_enabled || strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 )) {
             msgpack_sbuffer_init(&filtered_sbuf);
             msgpack_unpacked_init(&modified_unpacked);
         }
@@ -1323,10 +1330,13 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
             flb_plg_debug(ctx->ins, "Couldn't determine log group & stream for record with tag %s", tag);
             goto error;
         }
-        if(ctx->kubernete_metadata_enabled && ctx->add_entity) {
+        if(ctx->add_entity && ( ctx->kubernete_metadata_enabled || strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 )) {
             update_or_create_entity(ctx,stream,map);
             // Prepare a buffer to pack the modified map
             if(stream->entity != NULL && (stream->entity->root_filter_count > 0 || stream->entity->filter_count > 0)) {
+                if (strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
+                    flb_plg_info(ctx->ins, "stream->entity->root_filter_count %d", stream->entity->root_filter_count);
+                }
                 msgpack_packer pk;
                 msgpack_packer_init(&pk, &filtered_sbuf, msgpack_sbuffer_write);
                 remove_unneeded_field(&map, "kubernetes",&pk,stream->entity->root_filter_count, stream->entity->filter_count);
@@ -1456,7 +1466,7 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
         if (ret == 0) {
             i++;
         }
-        if(ctx->kubernete_metadata_enabled && ctx->add_entity) {
+        if(ctx->add_entity && ( ctx->kubernete_metadata_enabled || strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 )) {
             msgpack_sbuffer_destroy(&filtered_sbuf);
             msgpack_unpacked_destroy(&modified_unpacked);
         }
@@ -1475,7 +1485,7 @@ int process_and_send(struct flb_cloudwatch *ctx, const char *input_plugin,
 
 error:
     msgpack_unpacked_destroy(&result);
-    if(ctx->kubernete_metadata_enabled && ctx->add_entity) {
+    if(ctx->add_entity && ( ctx->kubernete_metadata_enabled || strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 )) {
         msgpack_sbuffer_destroy(&filtered_sbuf);
         msgpack_unpacked_destroy(&modified_unpacked);
     }
@@ -1886,7 +1896,8 @@ int put_log_events(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     int num_headers = 1;
     int retry = FLB_TRUE;
 
-    flb_plg_debug(ctx->ins, "Sending log events to log stream %s", stream->name);
+    flb_plg_info(ctx->ins, "Sending log events to log stream %s", stream->name);
+    flb_plg_info(ctx->ins, "data buf %s", buf->out_buf);
 
     /* stream is being used, update expiration */
     stream->expiration = time(NULL) + FOUR_HOURS_IN_SECONDS;
@@ -1909,9 +1920,9 @@ retry_request:
     }
 
     if (c) {
-        flb_plg_debug(ctx->ins, "PutLogEvents http status=%d", c->resp.status);
-        flb_plg_debug(ctx->ins, "PutLogEvents http data=%s", c->resp.data);
-        flb_plg_debug(ctx->ins, "PutLogEvents http payload=%s", c->resp.payload);
+        flb_plg_info(ctx->ins, "PutLogEvents http status=%d", c->resp.status);
+        flb_plg_info(ctx->ins, "PutLogEvents http data=%s", c->resp.data);
+        flb_plg_info(ctx->ins, "PutLogEvents http payload=%s", c->resp.payload);
 
         if (c->resp.status == 200) {
             if (c->resp.data == NULL || c->resp.data_len == 0 || strstr(c->resp.data, AMZN_REQUEST_ID_HEADER) == NULL) {

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -244,12 +244,12 @@ static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct
                       "\"keyAttributes\":{",0)) {
         goto error;
     }
-    if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-                        "\"Type\":\"Resource\"",0)) {
-        goto error;
-    }
     if(stream->entity->key_attributes->platform != NULL && strlen(stream->entity->key_attributes->platform) != 0) {
         if (strncmp(stream->entity->key_attributes->platform, EKS_PLATFORM, 3) == 0) {
+            if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                        "\"Type\":\"AWS::Resource\"",0)) {
+                goto error;
+            }
             if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"ResourceType\":\"","AWS::EKS::Cluster","\"")) {
                 goto error;
             }
@@ -257,6 +257,10 @@ static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct
                 goto error;
             }
         } else if (strncmp(stream->entity->key_attributes->platform, NATIVE_KUBERNETES_PLATFORM, 3) == 0) {
+            if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                        "\"Type\":\"Resource\"",0)) {
+                goto error;
+            }
             if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"ResourceType\":\"","K8s::Cluster","\"")) {
                 goto error;
             }

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -854,7 +854,6 @@ retry:
     }
 
     flb_plg_debug(ctx->ins, "cloudwatch:PutLogEvents: events=%d, payload=%d bytes", i, offset);
-    flb_plg_info(ctx->ins, "Sending payload=%s", buf->out_buf);
     ret = put_log_events(ctx, buf, buf->current_stream, (size_t) offset);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Failed to send log events");

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -286,7 +286,7 @@ static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct
         }
     }
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-              "}", 1)) {
+              "},", 2)) {
         goto error;
     }
     return 0;
@@ -391,6 +391,29 @@ error:
     return -1;
 }
 
+static int entity_add_resource_attributes(struct flb_cloudwatch *ctx, struct cw_flush *buf, struct log_stream *stream,int *offset) {
+    char ts[ATTRIBUTES_MAX_LEN];
+    if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                      "\"attributes\":{",
+                      0)) {
+        goto error;
+    }
+    if(stream->entity->attributes->instance_id != NULL && strlen(stream->entity->attributes->instance_id) != 0) {
+        if (!snprintf(ts,ATTRIBUTES_MAX_LEN, "%s%s%s","\"EC2.InstanceId\":\"",buf->current_stream->entity->attributes->instance_id,"\"")) {
+            goto error;
+        }
+        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,ts,0)) {
+            goto error;
+        }
+    }
+    if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+        "}", 1)) {
+        goto error;
+    }
+    return 0;
+error:
+    return -1;
+}
 /*
  * Writes the "header" for a put log events payload
  */
@@ -425,41 +448,50 @@ static int init_put_payload(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     // If we are missing the service name, the entity will get rejected by the frontend anyway
     // so do not emit entity unless service name is filled. If we are missing account ID
     // it is considered not having sufficient information for entity therefore we should drop the entity.
-    if(ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL && strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 && stream->entity->key_attributes->platform != NULL && stream->entity->key_attributes->cluster_name != NULL && stream->entity->key_attributes->account_id != NULL) {
-        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-                        "\"entity\":{", 10)) {
-                goto error;
-        }
-        ret = entity_add_resource_key_attributes(ctx,buf,stream,offset);
-        if (ret < 0) {
-            flb_plg_error(ctx->ins, "Failed to initialize Resource Entity KeyAttributes");
-            goto error;
-        }
-        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-                        "},", 2)) {
-            goto error;
-        }
-    }
-    else if (ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL && stream->entity->key_attributes->name != NULL && stream->entity->key_attributes->account_id != NULL) {
-        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-                        "\"entity\":{", 10)) {
-                goto error;
-        }
-        ret = entity_add_key_attributes(ctx,buf,stream,offset);
-        if (ret < 0) {
-            flb_plg_error(ctx->ins, "Failed to initialize Entity KeyAttributes");
-            goto error;
-        }
-        if(stream->entity->attributes != NULL) {
-            ret = entity_add_attributes(ctx,buf,stream,offset);
+    if(ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL && stream->entity->key_attributes->account_id != NULL) {
+        if(strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 && stream->entity->key_attributes->platform != NULL && stream->entity->key_attributes->cluster_name != NULL) {
+            if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                            "\"entity\":{", 10)) {
+                    goto error;
+            }
+            ret = entity_add_resource_key_attributes(ctx,buf,stream,offset);
             if (ret < 0) {
-                flb_plg_error(ctx->ins, "Failed to initialize Entity Attributes");
+                flb_plg_error(ctx->ins, "Failed to initialize Resource Entity KeyAttributes");
+                goto error;
+            }
+            if(stream->entity->attributes != NULL) {
+                ret = entity_add_resource_attributes(ctx,buf,stream,offset);
+                if (ret < 0) {
+                    flb_plg_error(ctx->ins, "Failed to initialize Resource Entity Attributes");
+                    goto error;
+                }
+            }
+            if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                            "},", 2)) {
                 goto error;
             }
         }
-        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-                        "},", 2)) {
-            goto error;
+        else if (strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0 && stream->entity->key_attributes->name != NULL) {
+            if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                            "\"entity\":{", 10)) {
+                    goto error;
+            }
+            ret = entity_add_key_attributes(ctx,buf,stream,offset);
+            if (ret < 0) {
+                flb_plg_error(ctx->ins, "Failed to initialize Entity KeyAttributes");
+                goto error;
+            }
+            if(stream->entity->attributes != NULL) {
+                ret = entity_add_attributes(ctx,buf,stream,offset);
+                if (ret < 0) {
+                    flb_plg_error(ctx->ins, "Failed to initialize Entity Attributes");
+                    goto error;
+                }
+            }
+            if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                            "},", 2)) {
+                goto error;
+            }
         }
     }
 
@@ -822,6 +854,7 @@ retry:
     }
 
     flb_plg_debug(ctx->ins, "cloudwatch:PutLogEvents: events=%d, payload=%d bytes", i, offset);
+    flb_plg_info(ctx->ins, "Sending payload=%s", buf->out_buf);
     ret = put_log_events(ctx, buf, buf->current_stream, (size_t) offset);
     if (ret < 0) {
         flb_plg_error(ctx->ins, "Failed to send log events");
@@ -1235,13 +1268,12 @@ void update_or_create_entity(struct flb_cloudwatch *ctx, struct log_stream *stre
             }
             memset(stream->entity->key_attributes, 0, sizeof(entity_key_attributes));
 
-            if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
-                stream->entity->attributes = flb_malloc(sizeof(entity_attributes));
-                if (stream->entity->attributes == NULL) {
-                    return;
-                }
-                memset(stream->entity->attributes, 0, sizeof(entity_attributes));
+            stream->entity->attributes = flb_malloc(sizeof(entity_attributes));
+            if (stream->entity->attributes == NULL) {
+                return;
             }
+            memset(stream->entity->attributes, 0, sizeof(entity_attributes));
+
             stream->entity->filter_count = 0;
             stream->entity->root_filter_count = 0;
             stream->entity->service_name_found = 0;

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -277,6 +277,14 @@ static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct
             goto error;
         }
     }
+    if(stream->entity->key_attributes->account_id != NULL && strlen(stream->entity->key_attributes->account_id) != 0) {
+        if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"AwsAccountId\":\"",stream->entity->key_attributes->account_id,"\"")) {
+            goto error;
+        }
+        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,ts,0)) {
+            goto error;
+        }
+    }
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
               "}", 1)) {
         goto error;
@@ -417,39 +425,41 @@ static int init_put_payload(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     // If we are missing the service name, the entity will get rejected by the frontend anyway
     // so do not emit entity unless service name is filled. If we are missing account ID
     // it is considered not having sufficient information for entity therefore we should drop the entity.
-    if(ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL ) {
+    if(ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL && strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 && stream->entity->key_attributes->platform != NULL && stream->entity->key_attributes->cluster_name != NULL && stream->entity->key_attributes->account_id != NULL) {
         if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
                         "\"entity\":{", 10)) {
                 goto error;
         }
-        if (strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0 && stream->entity->key_attributes->platform != NULL && stream->entity->key_attributes->cluster_name != NULL) {
-            if(stream->entity->key_attributes != NULL) {
-                ret = entity_add_resource_key_attributes(ctx,buf,stream,offset);
-                if (ret < 0) {
-                    flb_plg_error(ctx->ins, "Failed to initialize Resource Entity KeyAttributes");
-                    goto error;
-                }
-            }
+        ret = entity_add_resource_key_attributes(ctx,buf,stream,offset);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "Failed to initialize Resource Entity KeyAttributes");
+            goto error;
         }
-        else if (stream->entity->key_attributes->name != NULL && stream->entity->key_attributes->account_id != NULL) {
-            if(stream->entity->key_attributes != NULL) {
-                ret = entity_add_key_attributes(ctx,buf,stream,offset);
-                if (ret < 0) {
-                    flb_plg_error(ctx->ins, "Failed to initialize Entity KeyAttributes");
-                    goto error;
-                }
-            }
-            if(stream->entity->attributes != NULL) {
-                ret = entity_add_attributes(ctx,buf,stream,offset);
-                if (ret < 0) {
-                    flb_plg_error(ctx->ins, "Failed to initialize Entity Attributes");
-                    goto error;
-                }
+        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                        "},", 2)) {
+            goto error;
+        }
+    }
+    else if (ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL && stream->entity->key_attributes->name != NULL && stream->entity->key_attributes->account_id != NULL) {
+        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                        "\"entity\":{", 10)) {
+                goto error;
+        }
+        ret = entity_add_key_attributes(ctx,buf,stream,offset);
+        if (ret < 0) {
+            flb_plg_error(ctx->ins, "Failed to initialize Entity KeyAttributes");
+            goto error;
+        }
+        if(stream->entity->attributes != NULL) {
+            ret = entity_add_attributes(ctx,buf,stream,offset);
+            if (ret < 0) {
+                flb_plg_error(ctx->ins, "Failed to initialize Entity Attributes");
+                goto error;
             }
         }
         if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
                         "},", 2)) {
-                goto error;
+            goto error;
         }
     }
 

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -1126,6 +1126,33 @@ void parse_entity(struct flb_cloudwatch *ctx, entity *entity, msgpack_object map
             }
             entity->key_attributes->account_id = flb_strndup(val.via.str.ptr, val.via.str.size);
         }
+        if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
+            if(entity->key_attributes->type != NULL) {
+               flb_free(entity->key_attributes->platform);
+            }
+            entity->key_attributes->type = "Resource";
+        } else {
+            if(entity->key_attributes->type != NULL) {
+               flb_free(entity->key_attributes->platform);
+            }
+            entity->key_attributes->type = "Service";
+        }
+        if(strncmp(key.via.str.ptr, "aws_entity_platform",key.via.str.size ) == 0 ) {
+            if(entity->key_attributes->platform == NULL) {
+                entity->root_filter_count++;
+            } else {
+                flb_free(entity->key_attributes->platform);
+            }
+            entity->key_attributes->platform = flb_strndup(val.via.str.ptr, val.via.str.size);
+        }
+        if(strncmp(key.via.str.ptr, "aws_entity_cluster",key.via.str.size ) == 0 ) {
+            if(entity->key_attributes->cluster_name == NULL) {
+                entity->root_filter_count++;
+            } else {
+                flb_free(entity->key_attributes->cluster_name);
+            }
+            entity->key_attributes->cluster_name = flb_strndup(val.via.str.ptr, val.via.str.size);
+        }
     }
     if(entity->key_attributes->name == NULL && entity->attributes->name_source == NULL &&entity->attributes->workload != NULL) {
         entity->key_attributes->name = flb_strndup(entity->attributes->workload, strlen(entity->attributes->workload));
@@ -1150,16 +1177,21 @@ void update_or_create_entity(struct flb_cloudwatch *ctx, struct log_stream *stre
             }
             memset(stream->entity->key_attributes, 0, sizeof(entity_key_attributes));
 
-            stream->entity->attributes = flb_malloc(sizeof(entity_attributes));
-            if (stream->entity->attributes == NULL) {
-                return;
+            if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_SERVICE, FLB_FILTER_ENTITY_TYPE_SERVICE_LEN) == 0) {
+                stream->entity->attributes = flb_malloc(sizeof(entity_attributes));
+                if (stream->entity->attributes == NULL) {
+                    return;
+                }
+                memset(stream->entity->attributes, 0, sizeof(entity_attributes));
+                stream->entity->filter_count = 0;
+                stream->entity->root_filter_count = 0;
+                stream->entity->service_name_found = 0;
+                stream->entity->environment_found = 0;
+                stream->entity->name_source_found = 0;
+            } else if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
+                stream->entity->cluster_name_found = 0;
+                stream->entity->cluster_platform_found = 0;
             }
-            memset(stream->entity->attributes, 0, sizeof(entity_attributes));
-            stream->entity->filter_count = 0;
-            stream->entity->root_filter_count = 0;
-            stream->entity->service_name_found = 0;
-            stream->entity->environment_found = 0;
-            stream->entity->name_source_found = 0;
         }
         parse_entity(ctx,stream->entity,map, map.via.map.size);
         if (!stream->entity) {

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.c
@@ -238,6 +238,50 @@ error:
     return -1;
 }
 
+static int entity_add_resource_key_attributes(struct flb_cloudwatch *ctx, struct cw_flush *buf, struct log_stream *stream, int *offset) {
+    char ts[KEY_ATTRIBUTES_MAX_LEN];
+    if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                      "\"keyAttributes\":{",0)) {
+        goto error;
+    }
+    if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+                        "\"Type\":\"Resource\"",0)) {
+        goto error;
+    }
+    if(stream->entity->key_attributes->platform != NULL && strlen(stream->entity->key_attributes->platform) != 0) {
+        if (strncmp(stream->entity->key_attributes->platform, EKS_PLATFORM, 3)) {
+            if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"ResourceType\":\"","AWS::EKS::Cluster","\"")) {
+                goto error;
+            }
+            if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,ts,0)) {
+                goto error;
+            }
+        } else if (strncmp(stream->entity->key_attributes->platform, NATIVE_KUBERNETES_PLATFORM, 3)) {
+            if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"ResourceType\":\"","K8s::Cluster","\"")) {
+                goto error;
+            }
+            if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,ts,0)) {
+                goto error;
+            }
+        }   
+    }
+    if(stream->entity->key_attributes->cluster_name != NULL && strlen(stream->entity->key_attributes->cluster_name) != 0) {
+        if (!snprintf(ts,KEY_ATTRIBUTES_MAX_LEN, ",%s%s%s","\"Identifier\":\"",stream->entity->key_attributes->cluster_name,"\"")) {
+            goto error;
+        }
+        if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,ts,0)) {
+            goto error;
+        }
+    }
+    if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
+              "},", 2)) {
+        goto error;
+    }
+    return 0;
+error:
+    return -1;
+}
+
 static int entity_add_attributes(struct flb_cloudwatch *ctx, struct cw_flush *buf, struct log_stream *stream,int *offset) {
     char ts[ATTRIBUTES_MAX_LEN];
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
@@ -369,32 +413,42 @@ static int init_put_payload(struct flb_cloudwatch *ctx, struct cw_flush *buf,
     // If we are missing the service name, the entity will get rejected by the frontend anyway
     // so do not emit entity unless service name is filled. If we are missing account ID
     // it is considered not having sufficient information for entity therefore we should drop the entity.
-    if(ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL && stream->entity->key_attributes->name != NULL && stream->entity->key_attributes->account_id != NULL) {
+    if(ctx->add_entity && stream->entity != NULL && stream->entity->key_attributes != NULL ) {
         if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-                      "\"entity\":{", 10)) {
-            goto error;
-        }
-
-        if(stream->entity->key_attributes != NULL) {
-            ret = entity_add_key_attributes(ctx,buf,stream,offset);
-            if (ret < 0) {
-                flb_plg_error(ctx->ins, "Failed to initialize Entity KeyAttributes");
+                        "\"entity\":{", 10)) {
                 goto error;
+        }
+        if (strncmp(ctx->entity_type, FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
+            if(stream->entity->key_attributes != NULL) {
+                ret = entity_add_resource_key_attributes(ctx,buf,stream,offset);
+                if (ret < 0) {
+                    flb_plg_error(ctx->ins, "Failed to initialize Resource Entity KeyAttributes");
+                    goto error;
+                }
             }
         }
-        if(stream->entity->attributes != NULL) {
-            ret = entity_add_attributes(ctx,buf,stream,offset);
-            if (ret < 0) {
-                flb_plg_error(ctx->ins, "Failed to initialize Entity Attributes");
-                goto error;
+        else if (stream->entity->key_attributes->name != NULL && stream->entity->key_attributes->account_id != NULL) {
+            if(stream->entity->key_attributes != NULL) {
+                ret = entity_add_key_attributes(ctx,buf,stream,offset);
+                if (ret < 0) {
+                    flb_plg_error(ctx->ins, "Failed to initialize Entity KeyAttributes");
+                    goto error;
+                }
+            }
+            if(stream->entity->attributes != NULL) {
+                ret = entity_add_attributes(ctx,buf,stream,offset);
+                if (ret < 0) {
+                    flb_plg_error(ctx->ins, "Failed to initialize Entity Attributes");
+                    goto error;
+                }
             }
         }
         if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
-                      "},", 2)) {
-            goto error;
+                        "},", 2)) {
+                goto error;
         }
-
     }
+    
 
     if (!try_to_write(buf->out_buf, offset, buf->out_buf_size,
                       "\"logEvents\":[", 13)) {
@@ -1126,17 +1180,6 @@ void parse_entity(struct flb_cloudwatch *ctx, entity *entity, msgpack_object map
             }
             entity->key_attributes->account_id = flb_strndup(val.via.str.ptr, val.via.str.size);
         }
-        if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
-            if(entity->key_attributes->type != NULL) {
-               flb_free(entity->key_attributes->platform);
-            }
-            entity->key_attributes->type = "Resource";
-        } else {
-            if(entity->key_attributes->type != NULL) {
-               flb_free(entity->key_attributes->platform);
-            }
-            entity->key_attributes->type = "Service";
-        }
         if(strncmp(key.via.str.ptr, "aws_entity_platform",key.via.str.size ) == 0 ) {
             if(entity->key_attributes->platform == NULL) {
                 entity->root_filter_count++;
@@ -1183,15 +1226,12 @@ void update_or_create_entity(struct flb_cloudwatch *ctx, struct log_stream *stre
                     return;
                 }
                 memset(stream->entity->attributes, 0, sizeof(entity_attributes));
-                stream->entity->filter_count = 0;
-                stream->entity->root_filter_count = 0;
-                stream->entity->service_name_found = 0;
-                stream->entity->environment_found = 0;
-                stream->entity->name_source_found = 0;
-            } else if (strncmp(ctx->entity_type , FLB_FILTER_ENTITY_TYPE_RESOURCE, FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN) == 0) {
-                stream->entity->cluster_name_found = 0;
-                stream->entity->cluster_platform_found = 0;
             }
+            stream->entity->filter_count = 0;
+            stream->entity->root_filter_count = 0;
+            stream->entity->service_name_found = 0;
+            stream->entity->environment_found = 0;
+            stream->entity->name_source_found = 0;
         }
         parse_entity(ctx,stream->entity,map, map.via.map.size);
         if (!stream->entity) {

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.h
@@ -55,6 +55,11 @@
 #define FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN               8
 #define FLB_FILTER_ENTITY_TYPE_SERVICE                    "service"
 #define FLB_FILTER_ENTITY_TYPE_SERVICE_LEN                7
+/*
+ * Possible cluster platform values for aws plugin
+ */
+#define NATIVE_KUBERNETES_PLATFORM "k8s"
+#define EKS_PLATFORM "eks"
 
 #include "cloudwatch_logs.h"
 

--- a/plugins/out_cloudwatch_logs/cloudwatch_api.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_api.h
@@ -48,6 +48,14 @@
 #define AWS_ENTITY_PREFIX "aws_entity"
 #define AWS_ENTITY_PREFIX_LEN 10
 
+/*
+ * Possible entity type values for aws plugin
+ */
+#define FLB_FILTER_ENTITY_TYPE_RESOURCE                   "resource"
+#define FLB_FILTER_ENTITY_TYPE_RESOURCE_LEN               8
+#define FLB_FILTER_ENTITY_TYPE_SERVICE                    "service"
+#define FLB_FILTER_ENTITY_TYPE_SERVICE_LEN                7
+
 #include "cloudwatch_logs.h"
 
 void cw_flush_destroy(struct cw_flush *buf);

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -516,6 +516,8 @@ void entity_destroy(entity *entity) {
         flb_free(entity->key_attributes->name);
         flb_free(entity->key_attributes->type);
         flb_free(entity->key_attributes->account_id);
+        flb_free(entity->key_attributes->platform);
+        flb_free(entity->key_attributes->cluster_name);
         flb_free(entity->key_attributes);
     }
     flb_free(entity);

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.c
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.c
@@ -676,6 +676,12 @@ static struct flb_config_map config_map[] = {
     "add entity to PutLogEvent calls"
    },
 
+   {
+     FLB_CONFIG_MAP_STR, "entity_type", "service",
+     0, FLB_TRUE, offsetof(struct flb_cloudwatch, entity_type),
+     "store the entity type. Possible values resource or service"
+    },
+
     /* EOF */
     {0}
 };

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -40,8 +40,6 @@ typedef struct entity {
     int environment_found;
     int name_source_found;
     int root_filter_count;
-    int cluster_name_found;
-    int cluster_platform_found;
 }entity;
 
 /* KeyAttributes used for CloudWatch Entity object

--- a/plugins/out_cloudwatch_logs/cloudwatch_logs.h
+++ b/plugins/out_cloudwatch_logs/cloudwatch_logs.h
@@ -40,6 +40,8 @@ typedef struct entity {
     int environment_found;
     int name_source_found;
     int root_filter_count;
+    int cluster_name_found;
+    int cluster_platform_found;
 }entity;
 
 /* KeyAttributes used for CloudWatch Entity object
@@ -49,6 +51,8 @@ typedef struct entity_key_attributes {
     char *name;
     char *environment;
     char *account_id;
+    char *cluster_name;
+    char *platform;
 }entity_key_attributes;
 
 /* Attributes used for CloudWatch Entity object
@@ -194,6 +198,7 @@ struct flb_cloudwatch {
     int kubernete_metadata_enabled;
 
     int add_entity;
+    char *entity_type;
 };
 
 void flb_cloudwatch_ctx_destroy(struct flb_cloudwatch *ctx);

--- a/tests/runtime/out_cloudwatch.c
+++ b/tests/runtime/out_cloudwatch.c
@@ -46,6 +46,81 @@ void flb_test_cloudwatch_success(void)
     flb_destroy(ctx);
 }
 
+void flb_test_cloudwatch_entity_service_success(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* mocks calls- signals that we are in test mode */
+    setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx,in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "cloudwatch_logs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,"match", "test", NULL);
+    flb_output_set(ctx, out_ffd,"region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
+    flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
+    flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
+    flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
+    flb_output_set(ctx, out_ffd,"add_entity", "On", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD , (int) sizeof(JSON_TD) - 1);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
+void flb_test_cloudwatch_entity_resource_success(void)
+{
+    int ret;
+    flb_ctx_t *ctx;
+    int in_ffd;
+    int out_ffd;
+
+    /* mocks calls- signals that we are in test mode */
+    setenv("FLB_CLOUDWATCH_PLUGIN_UNDER_TEST", "true", 1);
+
+    ctx = flb_create();
+
+    in_ffd = flb_input(ctx, (char *) "lib", NULL);
+    TEST_CHECK(in_ffd >= 0);
+    flb_input_set(ctx,in_ffd, "tag", "test", NULL);
+
+    out_ffd = flb_output(ctx, (char *) "cloudwatch_logs", NULL);
+    TEST_CHECK(out_ffd >= 0);
+    flb_output_set(ctx, out_ffd,"match", "test", NULL);
+    flb_output_set(ctx, out_ffd,"region", "us-west-2", NULL);
+    flb_output_set(ctx, out_ffd,"log_group_name", "fluent", NULL);
+    flb_output_set(ctx, out_ffd,"log_stream_prefix", "from-fluent-", NULL);
+    flb_output_set(ctx, out_ffd,"auto_create_group", "On", NULL);
+    flb_output_set(ctx, out_ffd,"net.keepalive", "Off", NULL);
+    flb_output_set(ctx, out_ffd,"Retry_Limit", "1", NULL);
+    flb_output_set(ctx, out_ffd,"add_entity", "On", NULL);
+    flb_output_set(ctx, out_ffd,"entity_type", "resource", NULL);
+
+    ret = flb_start(ctx);
+    TEST_CHECK(ret == 0);
+
+    flb_lib_push(ctx, in_ffd, (char *) JSON_TD , (int) sizeof(JSON_TD) - 1);
+
+    sleep(2);
+    flb_stop(ctx);
+    flb_destroy(ctx);
+}
+
 void flb_test_cloudwatch_already_exists_create_group(void)
 {
     int ret;
@@ -350,6 +425,8 @@ void flb_test_cloudwatch_error_put_retention_policy(void)
 /* Test list */
 TEST_LIST = {
     {"success", flb_test_cloudwatch_success },
+    {"success_service_entity", flb_test_cloudwatch_entity_service_success },
+    {"success_resource_entity", flb_test_cloudwatch_entity_resource_success },
     {"group_already_exists", flb_test_cloudwatch_already_exists_create_group },
     {"stream_already_exists", flb_test_cloudwatch_already_exists_create_stream },
     {"create_group_error", flb_test_cloudwatch_error_create_group },


### PR DESCRIPTION
<!-- Provide summary of changes -->

- Modified aws filter plugin to extract additional resource entity attributes
- Modified cloudwatch logs output plugin to add resource entity in PLE calls 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [x] Example configuration file for the change
```
        dataplane-log.conf: |
          [INPUT]
            Name                systemd
            Tag                 dataplane.systemd.*
            Systemd_Filter      _SYSTEMD_UNIT=docker.service
            Systemd_Filter      _SYSTEMD_UNIT=containerd.service
            Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
            DB                  /var/fluent-bit/state/systemd.db
            Path                /var/log/journal
            Read_From_Tail      ${READ_FROM_TAIL}

          [INPUT]
            Name                tail
            Tag                 dataplane.tail.*
            Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
            multiline.parser    docker, cri
            DB                  /var/fluent-bit/state/flb_dataplane_tail.db
            Mem_Buf_Limit       50MB
            Skip_Long_Lines     On
            Refresh_Interval    10
            Rotate_Wait         30
            storage.type        filesystem
            Read_from_Head      ${READ_FROM_HEAD}

          [FILTER]
            Name                modify
            Match               dataplane.systemd.*
            Rename              _HOSTNAME                   hostname
            Rename              _SYSTEMD_UNIT               systemd_unit
            Rename              MESSAGE                     message
            Remove_regex        ^((?!hostname|systemd_unit|message).)*$

          [FILTER]
            Name                aws
            Match               dataplane.*
            imds_version        v2
            enable_entity       true
            entity_type         resource

          [OUTPUT]
            Name                cloudwatch_logs
            Match               dataplane.*
            region              ${AWS_REGION}
            log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
            log_stream_prefix   ${HOST_NAME}-
            auto_create_group   true
            extra_user_agent    container-insights
            entity_type         resource
            add_entity          true
        host-log.conf: |
          [INPUT]
            Name                tail
            Tag                 host.dmesg
            Path                /var/log/dmesg
            Key                 message
            DB                  /var/fluent-bit/state/flb_dmesg.db
            Mem_Buf_Limit       5MB
            Skip_Long_Lines     On
            Refresh_Interval    10
            Read_from_Head      ${READ_FROM_HEAD}

          [INPUT]
            Name                tail
            Tag                 host.messages
            Path                /var/log/messages
            Parser              syslog
            DB                  /var/fluent-bit/state/flb_messages.db
            Mem_Buf_Limit       5MB
            Skip_Long_Lines     On
            Refresh_Interval    10
            Read_from_Head      ${READ_FROM_HEAD}

          [INPUT]
            Name                tail
            Tag                 host.secure
            Path                /var/log/secure
            Parser              syslog
            DB                  /var/fluent-bit/state/flb_secure.db
            Mem_Buf_Limit       5MB
            Skip_Long_Lines     On
            Refresh_Interval    10
            Read_from_Head      ${READ_FROM_HEAD}

          [FILTER]
            Name                aws
            Match               host.*
            imds_version        v2
            enable_entity       true
            entity_type         resource

          [OUTPUT]
            Name                cloudwatch_logs
            Match               host.*
            region              ${AWS_REGION}
            log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
            log_stream_prefix   ${HOST_NAME}.
            auto_create_group   true
            extra_user_agent    container-insights
            entity_type         resource
            add_entity          true
```
- [x] Debug log output from testing the change
For Dataplane logs on EKS cluster
```
[2025/03/10 15:20:27] [ info] [output:cloudwatch_logs:cloudwatch_logs.1] Sending payload={"logGroupName":"/aws/containerinsights/test-agent/dataplane","logStreamName":"ip-192-168-28-20.ec2.internal-dataplane.systemd.kubelet.service","entity":{"keyAttributes":{"Type" │
│ :"AWS::Resource","ResourceType":"AWS::EKS::Cluster","Identifier":"test-agent","AwsAccountId":"9576888xxxxx"},"attributes":{"EC2.InstanceId":"i-0f1346635d4142476"}},"logEvents":[{"timestamp":1741620026570,"message":"{\"systemd_unit\":\"kubelet.service\",\"hostname\": │
│ \"ip-192-168-28-20.ec2.internal\",\"message\":\"E0310 15:20:26.569894    2598 pod_workers.go:965] \\\"Error syncing pod, skipping\\\" err=\\\"failed to \\\\\\\"StartContainer\\\\\\\" for \\\\\\\"opentelemetry-auto-instrumentation-nodejs\\\\\\\" with CrashLoopBackOff │
│ : \\\\\\\"back-off 5m0s restarting failed container=opentelemetry-auto-instrumentation-nodejs pod=nutrition-service-nodejs-77bcf76bc9-dz5kk_default(126e1ad2-79a8-4048-89bd-9dccee24b0ab)\\\\\\\"\\\" pod=\\\"default/nutrition-service-nodejs-77bcf76bc9-dz5kk\\\" podUID │
│ =126e1ad2-79a8-4048-89bd-9dccee24b0ab\",\"az\":\"us-east-1a\",\"ec2_instance_id\":\"i-0f1346635d4142476\"}"}]}   
```
Verifying entity by calling ListEntitiesForLogGroup

```
dev-dsk-poojardy-1d-9f6133ab % /apollo/env/envImprovement/bin/awscurl \
    --request POST \
    --header 'Content-Encoding: amz-1.0' \
    --header 'Content-Type: application/json' \
    --region=us-east-1 \
    --service logs \
    --header 'x-Amz-Target: com.amazonaws.logs.v20140328.Logs_20140328.ListEntitiesForLogGroup' \
    --data '{"logGroupIdentifier":"/aws/containerinsights/test-agent/dataplane"}' \
    https://logs.us-east-1.amazonaws.com
{"entities":[{"attributes":{"AWS.Resource.ARN":"arn:aws:eks:us-east-1:9576888xxxxx:cluster/test-agent"},"keyAttributes":{"Identifier":"test-agent","ResourceType":"AWS::EKS::Cluster","Type":"AWS::Resource"}}]}
```

Log event on cloudwatch console
```
{
    "systemd_unit": "kubelet.service",
    "hostname": "ip-192-168-28-20.ec2.internal",
    "message": "E0310 15:20:26.569894    2598 pod_workers.go:965] \"Error syncing pod, skipping\" err=\"failed to \\\"StartContainer\\\" for \\\"opentelemetry-auto-instrumentation-nodejs\\\" with CrashLoopBackOff: \\\"back-off 5m0s restarting failed container=opentelemetry-auto-instrumentation-nodejs pod=nutrition-service-nodejs-77bcf76bc9-dz5kk_default(126e1ad2-79a8-4048-89bd-9dccee24b0ab)\\\"\" pod=\"default/nutrition-service-nodejs-77bcf76bc9-dz5kk\" podUID=126e1ad2-79a8-4048-89bd-9dccee24b0ab",
    "az": "us-east-1a",
    "ec2_instance_id": "i-0f1346635d4142476"
}
```

For Host logs in EKS cluster

```
[2025/03/10 15:20:27] [ info] [output:cloudwatch_logs:cloudwatch_logs.2] Sending payload={"logGroupName":"/aws/containerinsights/test-agent/host","logStreamName":"ip-192-168-28-20.ec2.internal.host.messages","entity":{"keyAttributes":{"Type":"AWS::Resource","Resourc │
│ eType":"AWS::EKS::Cluster","Identifier":"test-agent","AwsAccountId":"9576888xxxxx"},"attributes":{"EC2.InstanceId":"i-0f1346635d4142476"}},"logEvents":[{"timestamp":1741620026000,"message":"{\"host\":\"ip-192-168-28-20\",\"ident\":\"kubelet\",\"message\":\"E0310 15: │
│ 20:26.569894    2598 pod_workers.go:965] \\\"Error syncing pod, skipping\\\" err=\\\"failed to \\\\\\\"StartContainer\\\\\\\" for \\\\\\\"opentelemetry-auto-instrumentation-nodejs\\\\\\\" with CrashLoopBackOff: \\\\\\\"back-off 5m0s restarting failed container=opent │
│ elemetry-auto-instrumentation-nodejs pod=nutrition-service-nodejs-77bcf76bc9-dz5kk_default(126e1ad2-79a8-4048-89bd-9dccee24b0ab)\\\\\\\"\\\" pod=\\\"default/nutrition-service-nodejs-77bcf76bc9-dz5kk\\\" podUID=126e1ad2-79a8-4048-89bd-9dccee24b0ab\",\"az\":\"us-east- │
│ 1a\",\"ec2_instance_id\":\"i-0f1346635d4142476\"}"}]}          
```
Verifying entity by calling ListEntitiesForLogGroup
```
dev-dsk-poojardy-1d-9f6133ab % /apollo/env/envImprovement/bin/awscurl \
    --request POST \
    --header 'Content-Encoding: amz-1.0' \
    --header 'Content-Type: application/json' \
    --region=us-east-1 \
    --service logs \
    --header 'x-Amz-Target: com.amazonaws.logs.v20140328.Logs_20140328.ListEntitiesForLogGroup' \
    --data '{"logGroupIdentifier":"/aws/containerinsights/test-agent/host"}' \
    https://logs.us-east-1.amazonaws.com
{"entities":[{"attributes":{"AWS.Resource.ARN":"arn:aws:eks:us-east-1:9576888xxxxx:cluster/test-agent"},"keyAttributes":{"Identifier":"test-agent","ResourceType":"AWS::EKS::Cluster","Type":"AWS::Resource"}}]}
```
Log event on cloudwatch console
```
{
    "host": "ip-192-168-28-20",
    "ident": "kubelet",
    "message": "E0310 15:20:26.569894    2598 pod_workers.go:965] \"Error syncing pod, skipping\" err=\"failed to \\\"StartContainer\\\" for \\\"opentelemetry-auto-instrumentation-nodejs\\\" with CrashLoopBackOff: \\\"back-off 5m0s restarting failed container=opentelemetry-auto-instrumentation-nodejs pod=nutrition-service-nodejs-77bcf76bc9-dz5kk_default(126e1ad2-79a8-4048-89bd-9dccee24b0ab)\\\"\" pod=\"default/nutrition-service-nodejs-77bcf76bc9-dz5kk\" podUID=126e1ad2-79a8-4048-89bd-9dccee24b0ab",
    "az": "us-east-1a",
    "ec2_instance_id": "i-0f1346635d4142476"
}
```

<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [x] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found
For cloudwatch logs output plugin: flb-rt-out_cloudwatch

```
SUCCESS: All unit tests have passed.
==25282== 
==25282== HEAP SUMMARY:
==25282==     in use at exit: 0 bytes in 0 blocks
==25282==   total heap usage: 2 allocs, 2 frees, 1,200 bytes allocated
==25282== 
==25282== All heap blocks were freed -- no leaks are possible
==25282== 
==25282== For lists of detected and suppressed errors, rerun with: -s
==25282== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
