### PR TITLE
in_opentelemetry: fix handling of content-length (CVE-2024-50609)

### DIFF
--- a/plugins/in_opentelemetry/opentelemetry_prot.c
+++ b/plugins/in_opentelemetry/opentelemetry_prot.c
@@ -280,6 +280,13 @@ int opentelemetry_prot_handle(struct flb_opentelemetry *ctx, struct http_conn *c
         return -1;
     }
 
+    if (request->data.len <= 0) {
+        flb_sds_destroy(tag);
+        mk_mem_free(uri);
+        send_response(conn, 400, "error: no payload found\n");
+        return -1;
+    }
+
     if (strcmp(uri, "/v1/metrics") == 0) {
         ret = process_payload_metrics(ctx, conn, tag, session, request);
     }


### PR DESCRIPTION
Original commit: https://github.com/fluent/fluent-bit/pull/9993/commits/104be946309fc7a1cb930667cef0f5af4773ce3d

CVE-2024-50609 was discovered [via fuzzing on later versions](https://www.ebryx.com/blogs/exploring-cve-2024-50608-and-cve-2024-50609), so uncertain whether it applies to 1.9.10. Still, the validation added as a fix is trivial and doesn't seem to meaningfully affect valid use-cases, so no harm in backporting it just in case.

Note: The original PR also fixed CVE-2024-50608. This is irrelevant to us, as our version does not have the `in_prometheus_remote_write` plugin.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
